### PR TITLE
one-logger: pass logger as an arg to middlewares

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -20,9 +20,10 @@ import (
 
 func main() {
 	api := NewMyApi("someDb")
-
+	l := log.New(context.Background(), os.Stdout, 1000)
 	mux := server.NewMux(
-		middleware.WithOpts("localhost", 8081),
+		l,
+		middleware.WithOpts("localhost", 8081, l),
 		server.Routes{
 			server.NewRoute(
 				"/api",

--- a/middleware/log.go
+++ b/middleware/log.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io"
 	mathRand "math/rand"
 	"net"
 	"net/http"
@@ -17,25 +16,19 @@ import (
 const logIDKey = string(log.CtxKey)
 
 // Log is a middleware that logs requests/responses.
-func Log(wrappedHandler http.HandlerFunc, domain string, logOutput io.Writer) http.HandlerFunc {
+func Log(wrappedHandler http.HandlerFunc, domain string, l log.Logger) http.HandlerFunc {
 	// We want different requests to share the same logger backed by the same circular buffere for storing logs.
 	// That way, if someone makes one request and it succeds then they make another one that errors.
 	// When the logs are been flushed for the request that errored, the logs for the request that succeeded will also be flushed.
 	// Thus app developers can be able to correlate issues/logs in much better way.
 	//
 	// However, each request should get its own context. That's why we call `logger.WithCtx` for every request.
-	mLogger := log.New(
-		context.Background(),
-		logOutput,
-		// enought to hold messages for 5reqs/sec for 15minutes.
-		5*60*15,
-	)
 
 	mathRand.Seed(time.Now().UTC().UnixNano())
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		logger := mLogger.WithCtx(ctx)
+		reqL := l.WithCtx(ctx)
 
 		{
 			// set cookie/headers/ctx for logID.
@@ -83,13 +76,13 @@ func Log(wrappedHandler http.HandlerFunc, domain string, logOutput io.Writer) ht
 				// Only log 10% of the errors.
 				shouldLog := mathRand.Intn(100) > 90
 				if shouldLog {
-					logger.Error(nil, flds)
+					reqL.Error(nil, flds)
 				}
 			} else if lrw.code >= http.StatusBadRequest {
 				// both client and server errors.
-				logger.Error(nil, flds)
+				reqL.Error(nil, flds)
 			} else {
-				logger.Info(flds)
+				reqL.Info(flds)
 			}
 		}()
 

--- a/middleware/log_test.go
+++ b/middleware/log_test.go
@@ -40,13 +40,17 @@ func someLogHandler(successMsg string) http.HandlerFunc {
 func TestLogMiddleware(t *testing.T) {
 	t.Parallel()
 
+	getLogger := func(w io.Writer) log.Logger {
+		return log.New(context.Background(), w, 500)
+	}
+
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 
 		logOutput := &bytes.Buffer{}
 		successMsg := "hello"
 		domain := "example.com"
-		wrappedHandler := Log(someLogHandler(successMsg), domain, logOutput)
+		wrappedHandler := Log(someLogHandler(successMsg), domain, getLogger(logOutput))
 
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodHead, "/someUri", nil)
@@ -76,7 +80,7 @@ func TestLogMiddleware(t *testing.T) {
 		errorMsg := "someLogHandler failed"
 		successMsg := "hello"
 		domain := "example.com"
-		wrappedHandler := Log(someLogHandler(successMsg), domain, logOutput)
+		wrappedHandler := Log(someLogHandler(successMsg), domain, getLogger(logOutput))
 
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodHead, "/someUri", nil)
@@ -117,7 +121,7 @@ func TestLogMiddleware(t *testing.T) {
 		successMsg := "hello"
 		errorMsg := "someLogHandler failed"
 		domain := "example.com"
-		wrappedHandler := Log(someLogHandler(successMsg), domain, logOutput)
+		wrappedHandler := Log(someLogHandler(successMsg), domain, getLogger(logOutput))
 
 		{
 			// first request that succeds
@@ -215,7 +219,7 @@ func TestLogMiddleware(t *testing.T) {
 		logOutput := &bytes.Buffer{}
 		successMsg := "hello"
 		domain := "example.com"
-		wrappedHandler := Log(someLogHandler(successMsg), domain, logOutput)
+		wrappedHandler := Log(someLogHandler(successMsg), domain, getLogger(logOutput))
 
 		someLogID := "hey-some-log-id:" + id.New()
 
@@ -253,7 +257,7 @@ func TestLogMiddleware(t *testing.T) {
 		domain := "example.com"
 		// for this concurrency test, we have to re-use the same wrappedHandler
 		// so that state is shared and thus we can see if there is any state which is not handled correctly.
-		wrappedHandler := Log(someLogHandler(successMsg), domain, logOutput)
+		wrappedHandler := Log(someLogHandler(successMsg), domain, getLogger(logOutput))
 
 		runhandler := func() {
 			rec := httptest.NewRecorder()

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -4,9 +4,9 @@ package middleware
 
 import (
 	"fmt"
-	"io"
 	"net/http"
-	"os"
+
+	"github.com/komuw/ong/log"
 )
 
 // ongMiddlewareErrorHeader is a http header that is set by Ong
@@ -23,7 +23,7 @@ type Opts struct {
 	allowedOrigins []string
 	allowedMethods []string
 	allowedHeaders []string
-	logOutput      io.Writer
+	l              log.Logger
 }
 
 // NewOpts returns a new opts.
@@ -33,7 +33,7 @@ func NewOpts(
 	allowedOrigins []string,
 	allowedMethods []string,
 	allowedHeaders []string,
-	logOutput io.Writer,
+	l log.Logger,
 ) Opts {
 	return Opts{
 		domain:         domain,
@@ -41,13 +41,13 @@ func NewOpts(
 		allowedOrigins: allowedOrigins,
 		allowedMethods: allowedMethods,
 		allowedHeaders: allowedHeaders,
-		logOutput:      logOutput,
+		l:              l,
 	}
 }
 
 // WithOpts returns a new opts that has sensible defaults.
-func WithOpts(domain string, httpsPort uint16) Opts {
-	return NewOpts(domain, httpsPort, nil, nil, nil, os.Stdout)
+func WithOpts(domain string, httpsPort uint16, l log.Logger) Opts {
+	return NewOpts(domain, httpsPort, nil, nil, nil, l)
 }
 
 // allDefaultMiddlewares is a middleware that bundles all the default/core middlewares into one.
@@ -64,7 +64,7 @@ func allDefaultMiddlewares(
 	allowedOrigins := o.allowedOrigins
 	allowedMethods := o.allowedOrigins
 	allowedHeaders := o.allowedHeaders
-	logOutput := o.logOutput
+	logger := o.l
 
 	// The way the middlewares are layered is:
 	// 1. Panic on the outer since we want it to watch all other middlewares.
@@ -104,9 +104,9 @@ func allDefaultMiddlewares(
 				),
 			),
 			domain,
-			logOutput,
+			logger,
 		),
-		logOutput,
+		logger,
 	)
 }
 

--- a/server/mux.go
+++ b/server/mux.go
@@ -1,9 +1,7 @@
 package server
 
 import (
-	"context"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/komuw/ong/log"
@@ -53,9 +51,9 @@ type mux struct {
 }
 
 // NewMux creates a new mux.
-func NewMux(opt middleware.Opts, rts Routes) *mux {
+func NewMux(l log.Logger, opt middleware.Opts, rts Routes) *mux {
 	m := &mux{
-		l:      log.New(context.Background(), os.Stdout, 1000),
+		l:      l,
 		router: http.NewServeMux(),
 	}
 

--- a/server/mux_test.go
+++ b/server/mux_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"bytes"
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -9,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/akshayjshah/attest"
+	"github.com/komuw/ong/log"
 	"github.com/komuw/ong/middleware"
 )
 
@@ -26,13 +29,15 @@ func TestMux(t *testing.T) {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	client := &http.Client{Transport: tr}
+	l := log.New(context.Background(), &bytes.Buffer{}, 500)
 
 	t.Run("unknown uri", func(t *testing.T) {
 		t.Parallel()
 
 		msg := "hello world"
 		mux := NewMux(
-			middleware.WithOpts("localhost", 443),
+			l,
+			middleware.WithOpts("localhost", 443, l),
 			Routes{
 				NewRoute(
 					"/api",
@@ -58,7 +63,8 @@ func TestMux(t *testing.T) {
 		uri := "/api/" // forward slash at suffix is important.
 		msg := "hello world"
 		mux := NewMux(
-			middleware.WithOpts("localhost", 443),
+			l,
+			middleware.WithOpts("localhost", 443, l),
 			Routes{
 				NewRoute(
 					uri,
@@ -101,7 +107,8 @@ func TestMux(t *testing.T) {
 		msg := "hello world"
 		uri := "/api"
 		mux := NewMux(
-			middleware.WithOpts("localhost", 443),
+			l,
+			middleware.WithOpts("localhost", 443, l),
 			Routes{
 				NewRoute(
 					uri,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"bytes"
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -12,6 +14,7 @@ import (
 	"time"
 
 	"github.com/akshayjshah/attest"
+	"github.com/komuw/ong/log"
 	"github.com/komuw/ong/middleware"
 )
 
@@ -153,6 +156,8 @@ func TestServer(t *testing.T) {
 	}
 	client := &http.Client{Transport: tr}
 
+	l := log.New(context.Background(), &bytes.Buffer{}, 500)
+
 	t.Run("tls", func(t *testing.T) {
 		t.Parallel()
 
@@ -167,7 +172,8 @@ func TestServer(t *testing.T) {
 		uri := "/api"
 		msg := "hello world"
 		mux := NewMux(
-			middleware.WithOpts("localhost", port),
+			l,
+			middleware.WithOpts("localhost", port, l),
 			Routes{
 				NewRoute(
 					uri,
@@ -232,7 +238,8 @@ func TestServer(t *testing.T) {
 		uri := "/api"
 		msg := "hello world"
 		mux := NewMux(
-			middleware.WithOpts("localhost", port),
+			l,
+			middleware.WithOpts("localhost", port, l),
 			Routes{
 				NewRoute(
 					uri,


### PR DESCRIPTION
Pass logger to middleware. This is so that the middlewares can share the same logger as the app.
This way, if the app ever logs an error, even the middleware logs will be flushed.
This makes debugging easier for developers
