### PR TITLE
efficient-err-stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,4 @@ Most recent version is listed first.
 - gzip almost everthing: https://github.com/komuw/ong/pull/83
 - pass logger as an arg to the middlewares: https://github.com/komuw/ong/pull/84
 - disable gzip: https://github.com/komuw/ong/pull/86
+- a more efficient error stack trace: https://github.com/komuw/ong/pull/87


### PR DESCRIPTION
Instead of using `stack []uintptr` to represent an errors stacktrace,
use `stack [4]uintptr` instead.
This idea is taken from golang/xerrors.
see: https://github.com/golang/xerrors/blob/65e65417b02f28de84b55f16b46a1e789149973a/frame.go#L13-L16

