### PR TITLE
automatically set GOMEMLIMIT in container environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,3 +42,4 @@ Most recent version is listed first.
 - update github.com/akshayjshah/attest: https://github.com/komuw/ong/pull/93
 - update to Go 1.19: https://github.com/komuw/ong/pull/102
 - remove rlimit code, go1.19 does automatically: https://github.com/komuw/ong/pull/104
+- automatically set GOMEMLIMIT in container environments: https://github.com/komuw/ong/pull/105

--- a/server/automaxmem/automaxmem.go
+++ b/server/automaxmem/automaxmem.go
@@ -1,0 +1,47 @@
+// Package automaxmem automatically sets GOMEMLIMIT to match the Linux
+// container memory quota, if any.
+package automaxmem
+
+import (
+	"os"
+	"runtime/debug"
+	"strconv"
+)
+
+const (
+	cgroupV1    = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+	cgroupv2    = "/sys/fs/cgroup/memory.max"
+	ignoreLimit = 10 * 1024 * 1024 // 10MB
+)
+
+// Set GOMEMLIMIT to match the Linux container memory quota (if any), returning an undo function.
+// It is a no-op on non-Linux systems and in Linux environments without a configured memory quota.
+func Set() func() {
+	prev := debug.SetMemoryLimit(-6) // negative input allows retrieval of the currently set memory limit.
+	undo := func() {
+		debug.SetMemoryLimit(prev)
+	}
+
+	// start with v2 since it is the most recent and we expect most systems to have it.
+	content, err := os.ReadFile(cgroupv2)
+	if err != nil {
+		content, err = os.ReadFile(cgroupV1)
+	}
+	if err != nil {
+		return undo
+	}
+
+	n, err := strconv.ParseInt(string(content), 10, 64)
+	if err != nil {
+		return undo
+	}
+
+	// set GOMEMLIMIT to 90% of cgroup's memory limit
+	limit := int64((90 / 100) * n) // limit in bytes.
+	if limit < ignoreLimit {
+		return undo
+	}
+	debug.SetMemoryLimit(limit)
+
+	return undo
+}

--- a/server/automaxmem/automaxmem.go
+++ b/server/automaxmem/automaxmem.go
@@ -14,21 +14,41 @@ const (
 	ignoreLimit = 10 * 1024 * 1024 // 10MB
 )
 
+// config is used for tests.
+type config struct {
+	cgroupV1 string
+	cgroupV2 string
+}
+
 // Set GOMEMLIMIT to match the Linux container memory quota (if any), returning an undo function.
 // It is a no-op on non-Linux systems and in Linux environments without a configured memory quota.
-func Set() func() {
-	prev := debug.SetMemoryLimit(-6) // negative input allows retrieval of the currently set memory limit.
+//
+// The optional argument c is only for test purposes.
+func Set(c ...config) func() {
+	prev := currentMaxMem()
 	undo := func() {
 		debug.SetMemoryLimit(prev)
 	}
 
-	// start with v2 since it is the most recent and we expect most systems to have it.
-	content, err := os.ReadFile(cgroupv2)
-	if err != nil {
-		content, err = os.ReadFile(cgroupV1)
-	}
-	if err != nil {
-		return undo
+	var content []byte
+	var err error
+	if len(c) > 0 {
+		content, err = os.ReadFile(c[0].cgroupV2)
+		if err != nil {
+			content, err = os.ReadFile(c[0].cgroupV1)
+		}
+		if err != nil {
+			return undo
+		}
+	} else {
+		// start with v2 since it is the most recent and we expect most systems to have it.
+		content, err = os.ReadFile(cgroupv2)
+		if err != nil {
+			content, err = os.ReadFile(cgroupV1)
+		}
+		if err != nil {
+			return undo
+		}
 	}
 
 	n, err := strconv.ParseInt(string(content), 10, 64)
@@ -37,11 +57,15 @@ func Set() func() {
 	}
 
 	// set GOMEMLIMIT to 90% of cgroup's memory limit
-	limit := int64((90 / 100) * n) // limit in bytes.
+	limit := int64(0.9 * float64(n)) // limit in bytes.
 	if limit < ignoreLimit {
 		return undo
 	}
 	debug.SetMemoryLimit(limit)
 
 	return undo
+}
+
+func currentMaxMem() int64 {
+	return debug.SetMemoryLimit(-6) // negative input allows retrieval of the currently set memory limit.
 }

--- a/server/server.go
+++ b/server/server.go
@@ -15,6 +15,7 @@ import (
 
 	ongErrors "github.com/komuw/ong/errors"
 	"github.com/komuw/ong/log"
+	"github.com/komuw/ong/server/automaxmem"
 
 	"go.uber.org/automaxprocs/maxprocs"
 	"golang.org/x/sys/unix" // syscall package is deprecated
@@ -42,7 +43,7 @@ type opts struct {
 	handlerTimeout    time.Duration
 	idleTimeout       time.Duration
 	tls               tlsOpts
-	// this ones are created automatically
+	// the following ones are created automatically
 	host          string
 	serverPort    string
 	serverAddress string
@@ -156,6 +157,7 @@ func withOpts(port uint16, certFile, keyFile, email, domain string) opts {
 // If the opts supplied include a certificate and key, the server will accept https traffic and also automatically handle http->https redirect.
 func Run(h http.Handler, o opts, l log.Logger) error {
 	_, _ = maxprocs.Set()
+	_ = automaxmem.Set()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
What:
- automatically set GOMEMLIMIT in container environments

Why:
- Fixes: https://github.com/komuw/ong/issues/100
- This is similar in spirit to go.uber.org/automaxprocs/maxprocs