### PR TITLE
Issues/114: redirect csrf failures to same url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Most recent version is listed first.
 - use latest semgrep-go linter: https://github.com/komuw/ong/pull/111
 - add semgrep linter: https://github.com/komuw/ong/pull/113
 - add ability to handle csrf tokens in a distributed setting: https://github.com/komuw/ong/pull/112
+- redirect csrf failures to same url: https://github.com/komuw/ong/pull/117
 
 ## v0.0.2
 - automatically set GOMAXPROCS in container environments, using internal package: https://github.com/komuw/ong/pull/106

--- a/middleware/csrf.go
+++ b/middleware/csrf.go
@@ -108,7 +108,14 @@ func Csrf(wrappedHandler http.HandlerFunc, secretKey []byte, domain string) http
 				//
 				cookie.Delete(w, csrfCookieName, domain)
 				w.Header().Set(ongMiddlewareErrorHeader, errCsrfTokenNotFound.Error())
-				http.Redirect(w, r, r.URL.String(), http.StatusSeeOther)
+				http.Redirect(
+					w,
+					r,
+					r.URL.String(),
+					// http 303(StatusSeeOther) is guaranteed by the spec to always use http GET.
+					// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303
+					http.StatusSeeOther,
+				)
 				return
 			}
 		}

--- a/middleware/csrf.go
+++ b/middleware/csrf.go
@@ -51,6 +51,7 @@ const (
 )
 
 // Csrf is a middleware that provides protection against Cross Site Request Forgeries.
+// If a csrf token is not provided(or is not valid), when it ought to have been; this middleware will issue a http GET redirect to the same url.
 func Csrf(wrappedHandler http.HandlerFunc, secretKey []byte, domain string) http.HandlerFunc {
 	if err := validKey(secretKey); err != nil {
 		panic(err)

--- a/middleware/csrf_test.go
+++ b/middleware/csrf_test.go
@@ -278,11 +278,8 @@ func TestCsrf(t *testing.T) {
 		res := rec.Result()
 		defer res.Body.Close()
 
-		rb, err := io.ReadAll(res.Body)
-		attest.Ok(t, err)
-
-		attest.Equal(t, res.StatusCode, http.StatusForbidden)
-		attest.Equal(t, string(rb), errCsrfTokenNotFound.Error()+"\n")
+		// it is redirected.
+		attest.Equal(t, res.StatusCode, http.StatusSeeOther)
 		attest.Zero(t, res.Header.Get(tokenHeader))
 		attest.Equal(t, len(res.Cookies()), 0)
 	})

--- a/middleware/log.go
+++ b/middleware/log.go
@@ -46,7 +46,9 @@ func Log(wrappedHandler http.HandlerFunc, domain string, l log.Logger) http.Hand
 				logIDKey,
 				logID,
 				domain,
-				// hopefully 15mins is enough.
+				// Hopefully 15mins is enough.
+				// Google considers a session to be 30mins.
+				// https://support.google.com/analytics/answer/2731565?hl=en#time-based-expiration
 				15*time.Minute,
 				false,
 			)

--- a/middleware/secret.go
+++ b/middleware/secret.go
@@ -19,10 +19,12 @@ import (
 // XChaCha20-Poly1305, unlinke aes-gcm, has no message limit per key.
 // It can safely encrypt an unlimited number of messages with the same key, without any limit to the size of a message.
 // see:
+//   - https://gist.github.com/komuw/4d44a25e1b6786100ffe0308106e80f2
 //   - https://libsodium.gitbook.io/doc/secret-key_cryptography/aead/chacha20-poly1305/xchacha20-poly1305_construction
 //   - https://pycryptodome.readthedocs.io/en/latest/src/cipher/chacha20_poly1305.html
 //
 // This file uses [chacha20poly1305.NewX] which is XChaCha20-Poly1305.
+//
 
 func rand(n1, n2 int) []byte {
 	b := make([]byte, n1, n2)


### PR DESCRIPTION
What:
- When a request fails csrf validation, redirect it to the same url using http GET

Why:
- It seems like it would make for a more intuitive customer experience.
- Fixes: https://github.com/komuw/ong/issues/114