### PR TITLE
Fix automax.SetMem on cgroupv1 systems

### DIFF
--- a/automax/automaxmem.go
+++ b/automax/automaxmem.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"runtime/debug"
 	"strconv"
+	"strings"
 )
 
 const (
@@ -40,7 +41,7 @@ func setMem(c ...config) func() {
 		}
 	}
 
-	n, err := strconv.ParseInt(string(content), 10, 64)
+	n, err := strconv.ParseInt(strings.TrimSpace(string(content)), 10, 64)
 	if err != nil {
 		return undo
 	}

--- a/automax/automaxmem_test.go
+++ b/automax/automaxmem_test.go
@@ -27,7 +27,7 @@ func TestSetMem(t *testing.T) {
 	})
 
 	cgroupV1Value := 125 * 1024 * 1024 // 125 MB
-	_, err = io.WriteString(f1, fmt.Sprint(cgroupV1Value))
+	_, err = io.WriteString(f1, fmt.Sprintln(cgroupV1Value))
 	attest.Ok(t, err)
 
 	cgroupV2Value := 456 * 1024 * 1024 // 456 MB


### PR DESCRIPTION
On an ubuntu 20.04 system (cgroupv1 system), `SetMem` failed silently to parse the limit from the cgroup file. This is because the file contents actually end with a newline character, that leads `strconv.ParseInt` to fail. Updated the test fixture accordingly.

I did not test on a cgroupv2 system, but my experience is that all these files end with a newline anyway, so I put the `strings.TrimSpace` in the common code path to be sure.