### PR TITLE
issues/162: Panic middleware should include correct stack trace.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Most recent version is listed first.  
 
 
+## v0.0.22
+- Panic middleware should include correct stack trace: https://github.com/komuw/ong/pull/164
+
 ## v0.0.21
 - Improve performance of calling Csrf middleware multiple times: https://github.com/komuw/ong/pull/161
 

--- a/middleware/panic.go
+++ b/middleware/panic.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/komuw/ong/errors"
 	"github.com/komuw/ong/log"
 )
 
@@ -43,7 +44,7 @@ func Panic(wrappedHandler http.HandlerFunc, l log.Logger) http.HandlerFunc {
 				w.Header().Del(ongMiddlewareErrorHeader) // remove header so that users dont see it.
 
 				if e, ok := errR.(error); ok {
-					reqL.Error(e, flds)
+					reqL.Error(errors.Wrap(e), flds) // wrap with ong/errors so that the log will have a stacktrace.
 				} else {
 					reqL.Error(nil, flds)
 				}


### PR DESCRIPTION
What:
- Panic middleware should include correct stack trace.

Why:
- Fixes: https://github.com/komuw/ong/issues/162