### PR TITLE
issues/167:  NewRoute should panic if handler is already wrapped in a ong/middleware 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Most recent version is listed first.
 ## v0.0.24
 - Set session cookie only if non-empty: https://github.com/komuw/ong/pull/170
 - Add ReloadProtector middleware: https://github.com/komuw/ong/pull/171
+- Creating a new route should panic if handler is already wrapped in an ong middleware: https://github.com/komuw/ong/pull/172
 
 ## v0.0.23
 - ong/client: Add log id http header: https://github.com/komuw/ong/pull/166

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -34,7 +34,7 @@ func NewRoute(
 ) Route {
 	h := getfunc(handler)
 	if strings.Contains(h, "ong/middleware/") &&
-		!strings.Contains(h, "middleware.BasicAuth") {
+		!strings.Contains(h, "ong/middleware.BasicAuth") {
 		// BasicAuth is allowed.
 		panic("the handler should not be wrapped with ong middleware")
 	}

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -34,7 +34,7 @@ func NewRoute(
 ) Route {
 	h := getfunc(handler)
 	if strings.Contains(h, "ong/middleware/") &&
-		!strings.Contains(h, "BasicAuth") {
+		!strings.Contains(h, "middleware.BasicAuth") {
 		// BasicAuth is allowed.
 		panic("the handler should not be wrapped with ong middleware")
 	}

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -3,8 +3,8 @@ package mux
 
 import (
 	"context"
-	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/komuw/ong/log"
 	"github.com/komuw/ong/middleware"
@@ -25,24 +25,20 @@ const (
 )
 
 // NewRoute creates a new Route.
+//
+// It panics if handler has already been wrapped with ong/middleware
 func NewRoute(
 	pattern string,
 	method string,
 	handler http.HandlerFunc,
 ) Route {
-	// todo: restore this logic.
-	// Right now the logic is disabled because of `BasicAuth`
-	//
-	// if strings.Contains(
-	// 	getfunc(handler),
-	// 	"ong/middleware/",
-	// ) {
-	// 	panic("the handler should not be wrapped with ong middleware")
-	// }
+	h := getfunc(handler)
+	if strings.Contains(h, "ong/middleware/") &&
+		!strings.Contains(h, "BasicAuth") {
+		// BasicAuth is allowed.
+		panic("the handler should not be wrapped with ong middleware")
+	}
 
-	fmt.Println("\n\n\t ")
-	fmt.Println(getfunc(handler))
-	fmt.Println("\n\n\t ")
 	return Route{
 		method:          method,
 		pattern:         pattern,

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -3,6 +3,7 @@ package mux
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/komuw/ong/log"
@@ -39,6 +40,9 @@ func NewRoute(
 	// 	panic("the handler should not be wrapped with ong middleware")
 	// }
 
+	fmt.Println("\n\n\t ")
+	fmt.Println(getfunc(handler))
+	fmt.Println("\n\n\t ")
 	return Route{
 		method:          method,
 		pattern:         pattern,

--- a/mux/mux_test.go
+++ b/mux/mux_test.go
@@ -34,7 +34,7 @@ func thisIsAnitherMuxHandler() http.HandlerFunc {
 func TestNewRoute(t *testing.T) {
 	t.Parallel()
 
-	// l := log.New(&bytes.Buffer{}, 500)
+	l := log.New(&bytes.Buffer{}, 500)
 
 	// succeds
 	_ = NewRoute(
@@ -43,20 +43,24 @@ func TestNewRoute(t *testing.T) {
 		someMuxHandler("msg"),
 	)
 
-	// todo: restore this logic.
-	// Right now the logic is disabled because of `BasicAuth`
-	//
+	// succeds
+	_ = NewRoute(
+		"/api",
+		MethodGet,
+		middleware.BasicAuth(someMuxHandler("msg"), "some-user", "some-very-very-hard-passwd"),
+	)
+
 	// fails
-	// attest.Panics(t, func() {
-	// 	_ = NewRoute(
-	// 		"/api",
-	// 		MethodGet,
-	// 		middleware.Get(
-	// 			someMuxHandler("msg"),
-	// 			middleware.WithOpts("localhost", 443, getSecretKey(), l),
-	// 		),
-	// 	)
-	// })
+	attest.Panics(t, func() {
+		_ = NewRoute(
+			"/api",
+			MethodGet,
+			middleware.Get(
+				someMuxHandler("msg"),
+				middleware.WithOpts("localhost", 443, getSecretKey(), l),
+			),
+		)
+	})
 }
 
 func TestMux(t *testing.T) {


### PR DESCRIPTION
What:
-  mux.NewRoute should panic if handler is already wrapped in a ong/middleware 

Why:
- Fixes: https://github.com/komuw/ong/issues/167