### PR TITLE
ong/log: WithCtx should only use the id from context, if that ctx actually contains an Id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Most recent version is listed first.
 ## v0.0.28
 - ong/id should generate strings of the exact requested length: https://github.com/komuw/ong/pull/192
 - Do not quote special characters: https://github.com/komuw/ong/pull/193
+- WithCtx should only use the id from context, if that ctx actually contains an Id: https://github.com/komuw/ong/pull/196
 
 ## v0.0.27
 - Add Get cookie function: https://github.com/komuw/ong/pull/189

--- a/client/client.go
+++ b/client/client.go
@@ -106,7 +106,8 @@ func (lr *loggingRT) RoundTrip(req *http.Request) (res *http.Response, err error
 		}
 	}()
 
-	req.Header.Set(logIDHeader, log.GetId(ctx))
+	id, _ := log.GetId(ctx)
+	req.Header.Set(logIDHeader, id)
 
 	return lr.RoundTripper.RoundTrip(req)
 }

--- a/example/main.go
+++ b/example/main.go
@@ -53,7 +53,7 @@ func main() {
 		),
 	)
 
-	err := server.Run(mux, server.DevOpts(), l)
+	err := server.Run(mux, server.DevOpts(l), l)
 	if err != nil {
 		l.Error(err, log.F{"msg": "server.Run error"})
 		os.Exit(1)

--- a/middleware/log.go
+++ b/middleware/log.go
@@ -204,7 +204,8 @@ func getLogId(req *http.Request) string {
 	}
 
 	fromCtx := func(ctx context.Context) string {
-		return log.GetId(ctx)
+		id, _ := log.GetId(ctx)
+		return id
 	}
 
 	// get logid in order of preference;

--- a/server/cert_test.go
+++ b/server/cert_test.go
@@ -1,10 +1,12 @@
 package server
 
 import (
+	"bytes"
 	"os"
 	"testing"
 
 	"github.com/akshayjshah/attest"
+	"github.com/komuw/ong/log"
 )
 
 func TestCreateDevCertKey(t *testing.T) {
@@ -23,7 +25,8 @@ func TestCreateDevCertKey(t *testing.T) {
 		os.Remove(certPath)
 		os.Remove(keyPath)
 
-		_, _ = CreateDevCertKey()
+		l := log.New(&bytes.Buffer{}, 500)
+		_, _ = CreateDevCertKey(l)
 
 		_, err := os.Stat(certPath)
 		attest.Ok(t, err)

--- a/server/example_test.go
+++ b/server/example_test.go
@@ -30,7 +30,7 @@ func ExampleRun() {
 		),
 	)
 
-	opts := server.DevOpts() // dev options.
+	opts := server.DevOpts(l) // dev options.
 	// alternatively for production:
 	//   opts := server.LetsEncryptOpts("email@email.com", "*.some-domain.com")
 	err := server.Run(mux, opts, l)

--- a/server/server.go
+++ b/server/server.go
@@ -127,13 +127,13 @@ func NewOpts(
 
 // DevOpts returns a new Opts that has sensible defaults for tls, especially for dev environments.
 // It also automatically creates the dev certifiates/key by internally calling [CreateDevCertKey]
-func DevOpts() Opts {
+func DevOpts(l log.Logger) Opts {
 	if os.Getenv("ONG_RUNNING_IN_TESTS") == "" {
 		// This means we are not in CI. Thus, create dev certificates.
 		//
 		// This function call fails in CI with `permission denied`
 		// since it is trying to create certificates in filesystem.
-		_, _ = CreateDevCertKey()
+		_, _ = CreateDevCertKey(l)
 	}
 	certFile, keyFile := certKeyPaths()
 	return withOpts(65081, certFile, keyFile, "", "localhost")

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -195,7 +195,7 @@ func TestServer(t *testing.T) {
 		}()
 
 		// await for the server to start.
-		time.Sleep(7 * time.Second)
+		time.Sleep(11 * time.Second)
 
 		{
 			// https server.
@@ -285,7 +285,7 @@ func TestServer(t *testing.T) {
 		}()
 
 		// await for the server to start.
-		time.Sleep(7 * time.Second)
+		time.Sleep(11 * time.Second)
 
 		runhandler := func() {
 			res, err := client.Get(fmt.Sprintf("https://127.0.0.1:%d%s", port, uri)) // note: the https scheme.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -71,7 +71,8 @@ func TestOpts(t *testing.T) {
 	t.Run("default opts", func(t *testing.T) {
 		t.Parallel()
 
-		got := DevOpts()
+		l := log.New(&bytes.Buffer{}, 500)
+		got := DevOpts(l)
 		want := Opts{
 			port:              65081,
 			host:              "127.0.0.1",
@@ -123,7 +124,8 @@ func TestOpts(t *testing.T) {
 	t.Run("default tls opts", func(t *testing.T) {
 		t.Parallel()
 
-		got := DevOpts()
+		l := log.New(&bytes.Buffer{}, 500)
+		got := DevOpts(l)
 		want := Opts{
 			port:              65081,
 			host:              "127.0.0.1",
@@ -186,9 +188,9 @@ func TestServer(t *testing.T) {
 		)
 
 		go func() {
-			_, _ = CreateDevCertKey()
+			_, _ = CreateDevCertKey(l)
 			time.Sleep(1 * time.Second)
-			err := Run(mux, DevOpts(), l)
+			err := Run(mux, DevOpts(l), l)
 			attest.Ok(t, err)
 		}()
 
@@ -277,7 +279,7 @@ func TestServer(t *testing.T) {
 		)
 
 		go func() {
-			certFile, keyFile := CreateDevCertKey()
+			certFile, keyFile := CreateDevCertKey(l)
 			err := Run(mux, withOpts(port, certFile, keyFile, "", "localhost"), l)
 			attest.Ok(t, err)
 		}()


### PR DESCRIPTION
Imagine;
```go
l := log.New(w, 10)
fmt.Println(l.logId)

ctx := context.Background()

l2 := l.WithCtx(ctx)

fmt.Println(l.logId)
```

Previously, this would print two different logId's. This is because `WithCtx` would try to fetch a logId from `ctx` and if it can't, it would generate a new one.
In this PR, `WithCtx` does the same; but if `ctx` has no logId, then it re-uses the logId from `l`
