### PR TITLE
issues/197: ong/errors; wrap as deep as possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Most recent version is listed first.
 - ong/id should generate strings of the exact requested length: https://github.com/komuw/ong/pull/192
 - Do not quote special characters: https://github.com/komuw/ong/pull/193
 - WithCtx should only use the id from context, if that ctx actually contains an Id: https://github.com/komuw/ong/pull/196
+- ong/errors; wrap as deep as possible: https://github.com/komuw/ong/pull/199
 
 ## v0.0.27
 - Add Get cookie function: https://github.com/komuw/ong/pull/189

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -15,7 +15,7 @@ import (
 
 // stackError is an implementation of error that adds stack trace support and error wrapping.
 type stackError struct {
-	stack [4]uintptr
+	stack []uintptr
 	err   error
 }
 
@@ -51,14 +51,17 @@ func wrap(err error, skip int) error {
 		return err
 	}
 
-	stack := [4]uintptr{}
+	// limit stack size to 64 call depth.
+	// `pkgsite/derrors` limits it to 16K(16 * 1024)
+	// https://github.com/golang/pkgsite/blob/035bfc02f3faa0221e0edf90b0a21d3619c95fdd/internal/derrors/derrors.go#L261-L264
+	stack := [64]uintptr{}
 	// skip 0 identifies the frame for `runtime.Callers` itself and
 	// skip 1 identifies the caller of `runtime.Callers`(ie of `wrap`).
-	_ = runtime.Callers(skip, stack[:])
+	n := runtime.Callers(skip, stack[:])
 
 	return &stackError{
 		err:   err,
-		stack: stack,
+		stack: stack[:n],
 	}
 }
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -41,11 +41,16 @@ func New(text string) error {
 }
 
 // Wrap returns err, capturing a stack trace.
+// It is a no-op if err had already been wrapped by this library.
 func Wrap(err error) error {
 	return wrap(err, 3)
 }
 
 func wrap(err error, skip int) error {
+	if _, ok := err.(*stackError); ok {
+		return err
+	}
+
 	stack := [4]uintptr{}
 	// skip 0 identifies the frame for `runtime.Callers` itself and
 	// skip 1 identifies the caller of `runtime.Callers`(ie of `wrap`).

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -96,6 +96,25 @@ func TestStackError(t *testing.T) {
 				attest.Subsequence(t, stackTrace, v, attest.Sprintf("\n\t%s: not found in stackTrace: %s", v, stackTrace))
 			}
 		})
+
+		t.Run("late wrapping does not affect traces", func(t *testing.T) {
+			t.Parallel()
+
+			err := lateWrapping()
+
+			sterr, ok := err.(*stackError)
+			attest.True(t, ok)
+
+			stackTrace := sterr.getStackTrace()
+			for _, v := range []string{
+				"ong/errors/errors_test.go:29",
+				"ong/errors/errors_test.go:22",
+				"ong/errors/errors_test.go:16",
+				"ong/errors/errors_test.go:52",
+			} {
+				attest.Subsequence(t, stackTrace, v, attest.Sprintf("\n\t%s: not found in stackTrace: %s", v, stackTrace))
+			}
+		})
 	})
 
 	t.Run("formattting", func(t *testing.T) {
@@ -112,7 +131,7 @@ func TestStackError(t *testing.T) {
 			"ong/errors/errors_test.go:29",
 			"ong/errors/errors_test.go:22",
 			"ong/errors/errors_test.go:16",
-			"ong/errors/errors_test.go:104",
+			"ong/errors/errors_test.go:123",
 		} {
 			attest.Subsequence(t, extendedFormatting, v, attest.Sprintf("\n\t%s: not found in extendedFormatting: %s", v, extendedFormatting))
 		}

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -48,6 +48,10 @@ func open(p string) error {
 	return nil
 }
 
+func lateWrapping() error {
+	return Wrap(hello())
+}
+
 func TestStackError(t *testing.T) {
 	t.Parallel()
 
@@ -68,7 +72,7 @@ func TestStackError(t *testing.T) {
 				"ong/errors/errors_test.go:29",
 				"ong/errors/errors_test.go:22",
 				"ong/errors/errors_test.go:16",
-				"ong/errors/errors_test.go:60",
+				"ong/errors/errors_test.go:64",
 			} {
 				attest.Subsequence(t, stackTrace, v, attest.Sprintf("\n\t%s: not found in stackTrace: %s", v, stackTrace))
 			}
@@ -87,7 +91,7 @@ func TestStackError(t *testing.T) {
 			for _, v := range []string{
 				"ong/errors/errors_test.go:44",
 				"ong/errors/errors_test.go:35",
-				"ong/errors/errors_test.go:80",
+				"ong/errors/errors_test.go:84",
 			} {
 				attest.Subsequence(t, stackTrace, v, attest.Sprintf("\n\t%s: not found in stackTrace: %s", v, stackTrace))
 			}
@@ -108,7 +112,7 @@ func TestStackError(t *testing.T) {
 			"ong/errors/errors_test.go:29",
 			"ong/errors/errors_test.go:22",
 			"ong/errors/errors_test.go:16",
-			"ong/errors/errors_test.go:100",
+			"ong/errors/errors_test.go:104",
 		} {
 			attest.Subsequence(t, extendedFormatting, v, attest.Sprintf("\n\t%s: not found in extendedFormatting: %s", v, extendedFormatting))
 		}


### PR DESCRIPTION
Given;
```go
func a() error { 
   _, err := os.ReadFile("/non/existent.txt")  // line 2
    return errors.Wrap(err)                            // line 3
}
func b() error { return a() }                           // line 5
func c() error { return b() }                           // line 6

func main() {
    err := errors.Wrap(c())                            // line 9
    fmt.Printf("%+#v",  err)
}
```
This should print the whole stack trace starting with the line 9, line 6, .... line 3

- Fixes: https://github.com/komuw/ong/issues/197