### PR TITLE
issues/198: Add errors.Dwrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Most recent version is listed first.
 - Do not quote special characters: https://github.com/komuw/ong/pull/193
 - WithCtx should only use the id from context, if that ctx actually contains an Id: https://github.com/komuw/ong/pull/196
 - ong/errors; wrap as deep as possible: https://github.com/komuw/ong/pull/199
+- ong/errors; add errors.Dwrap: https://github.com/komuw/ong/pull/200
 
 ## v0.0.27
 - Add Get cookie function: https://github.com/komuw/ong/pull/189

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -46,6 +46,14 @@ func Wrap(err error) error {
 	return wrap(err, 3)
 }
 
+// Dwrap adds stack traces to the error.
+// It does nothing when *errp == nil.
+func Dwrap(errp *error) {
+	if *errp != nil {
+		*errp = wrap(*errp, 3)
+	}
+}
+
 func wrap(err error, skip int) error {
 	if _, ok := err.(*stackError); ok {
 		return err

--- a/errors/example_test.go
+++ b/errors/example_test.go
@@ -2,8 +2,10 @@ package errors_test
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/komuw/ong/errors"
+	"golang.org/x/exp/slices"
 )
 
 const expectedUser = "admin"
@@ -19,4 +21,27 @@ func login(user string) error {
 func Example_stackTraceFormatting() {
 	err := login("badGuy")
 	fmt.Printf("%+v", err)
+}
+
+func ExampleWrap() {
+	_, err := os.Open("/this/file/does/not/exist.txt")
+	if err != nil {
+		errors.Wrap(err)
+	}
+}
+
+func ExampleDwrap() {
+	fetchUser := func(u string) (errp error) {
+		defer errors.Dwrap(&errp)
+
+		users := []string{"John", "Alice", "Kamau"}
+		if !slices.Contains(users, u) {
+			return fmt.Errorf("user %s not found", u)
+		}
+
+		return nil
+	}
+
+	e := fetchUser("Emmy")
+	fmt.Printf("%+#v", e)
 }

--- a/errors/example_test.go
+++ b/errors/example_test.go
@@ -24,10 +24,15 @@ func Example_stackTraceFormatting() {
 }
 
 func ExampleWrap() {
-	_, err := os.Open("/this/file/does/not/exist.txt")
-	if err != nil {
-		errors.Wrap(err)
+	opener := func(p string) error {
+		_, err := os.Open(p)
+		if err != nil {
+			return errors.Wrap(err)
+		}
+		return nil
 	}
+
+	fmt.Printf("%+v", opener("/this/file/does/not/exist.txt"))
 }
 
 func ExampleDwrap() {

--- a/id/example_test.go
+++ b/id/example_test.go
@@ -9,3 +9,12 @@ import (
 func ExampleNew() {
 	fmt.Println(id.New())
 }
+
+func ExampleRandom() {
+	size := 34
+	s := id.Random(size)
+	if len(s) != size {
+		panic("mismatched sizes")
+	}
+	fmt.Println(s)
+}

--- a/id/example_test.go
+++ b/id/example_test.go
@@ -1,0 +1,11 @@
+package id_test
+
+import (
+	"fmt"
+
+	"github.com/komuw/ong/id"
+)
+
+func ExampleNew() {
+	fmt.Println(id.New())
+}


### PR DESCRIPTION
- Usage;
```go
func fetchUser(u string) (errp error) {
	defer errors.Dwrap(&errp)

	users := []string{"John", "Alice", "Kamau"}
	if !slices.Contains(users, u) {
		return fmt.Errorf("user %s not found", u)
	}

	return nil
}

e := fetchUser("Emmy")
fmt.Printf("%+#v", e)
```
- Fixes: https://github.com/komuw/ong/issues/198
- Inspired by https://github.com/golang/pkgsite/blob/035bfc02f3faa0221e0edf90b0a21d3619c95fdd/internal/derrors/derrors.go#L212-L237