### PR TITLE
ong/id: fix bug where strings were not of specified length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Most recent version is listed first.
 - WithCtx should only use the id from context, if that ctx actually contains an Id: https://github.com/komuw/ong/pull/196
 - ong/errors; wrap as deep as possible: https://github.com/komuw/ong/pull/199
 - ong/errors; add errors.Dwrap: https://github.com/komuw/ong/pull/200
+- ong/id, bug fix where ids generated were not always of the requested length; https://github.com/komuw/ong/pull/201
 
 ## v0.0.27
 - Add Get cookie function: https://github.com/komuw/ong/pull/189

--- a/id/id.go
+++ b/id/id.go
@@ -53,5 +53,5 @@ func Random(n int) string {
 		_, _ = mathRand.Read(b) // docs say that it always returns a nil error.
 	}
 
-	return enc.EncodeToString(b)
+	return enc.EncodeToString(b)[:n]
 }

--- a/id/id_test.go
+++ b/id/id_test.go
@@ -53,4 +53,15 @@ func TestNew(t *testing.T) {
 			attest.NotZero(t, got)
 		}
 	})
+
+	t.Run("range", func(t *testing.T) {
+		t.Parallel()
+
+		for i := 1; i <= 10_001; i++ {
+			got := Random(i)
+			attest.NotZero(t, got)
+			_len := len(got)
+			attest.Equal(t, _len, i, attest.Sprintf("input(%d), got len(%d) ", i, _len))
+		}
+	})
 }

--- a/id/id_test.go
+++ b/id/id_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/akshayjshah/attest"
+	"golang.org/x/exp/slices"
 )
 
 func TestNew(t *testing.T) {
@@ -62,6 +63,24 @@ func TestNew(t *testing.T) {
 			attest.NotZero(t, got)
 			_len := len(got)
 			attest.Equal(t, _len, i, attest.Sprintf("input(%d), got len(%d) ", i, _len))
+		}
+	})
+
+	t.Run("no dupes", func(t *testing.T) {
+		t.Parallel()
+
+		seen := []string{}
+		for i := 1; i <= 10_001; i++ {
+			got := New()
+			attest.NotZero(t, got)
+			_len := len(got)
+			attest.Equal(t, _len, 16, attest.Sprintf("input(%d), got len(%d) ", i, _len))
+
+			if slices.Contains(seen, got) {
+				t.Fatal("Random produced duplicates")
+			} else {
+				seen = append(seen, got)
+			}
 		}
 	})
 }


### PR DESCRIPTION
This occurred beause; https://github.com/komuw/ong/blob/1e8c51c371cb5888422de891085af87a3d0adb79/id/id.go#L46 does not produce a whole integer always;
```go
>>> n=301
>>> ((((n * 6) - 5) / 8) + 1)
226.125
```