### PR TITLE
issues/149: use net.Dialer.ControlContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Most recent version is listed first.
 
 ## v0.0.30
 - Update to Go v1.20: https://github.com/komuw/ong/pull/209
+- Use net.Dialer.ControlContext instead of use net.Dialer.Control: https://github.com/komuw/ong/pull/212
 
 ## v0.0.29
 - WithCtx should only use the id from context, if that ctx actually contains an Id: https://github.com/komuw/ong/pull/196

--- a/client/client.go
+++ b/client/client.go
@@ -3,6 +3,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -46,7 +47,7 @@ func new(ssrfSafe bool, l log.Logger) *http.Client {
 	timeout := 3 * 2 * time.Second
 
 	dialer := &net.Dialer{
-		Control: ssrfSocketControl(ssrfSafe),
+		ControlContext: ssrfSocketControl(ssrfSafe),
 		// see: net.DefaultResolver
 		Resolver: &net.Resolver{
 			// Prefer Go's built-in DNS resolver.
@@ -112,12 +113,12 @@ func (lr *loggingRT) RoundTrip(req *http.Request) (res *http.Response, err error
 	return lr.RoundTripper.RoundTrip(req)
 }
 
-func ssrfSocketControl(ssrfSafe bool) func(network, address string, conn syscall.RawConn) error {
+func ssrfSocketControl(ssrfSafe bool) func(ctx context.Context, network, address string, c syscall.RawConn) error {
 	if !ssrfSafe {
 		return nil
 	}
 
-	return func(network, address string, conn syscall.RawConn) error {
+	return func(ctx context.Context, network, address string, c syscall.RawConn) error {
 		if !(network == "tcp4" || network == "tcp6") {
 			return fmt.Errorf("%s %s is not a safe network type", errPrefix, network)
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -47,6 +47,9 @@ func new(ssrfSafe bool, l log.Logger) *http.Client {
 	timeout := 3 * 2 * time.Second
 
 	dialer := &net.Dialer{
+		// Using Dialer.ControlContext instead of Dialer.Control allows;
+		// - propagation of logging contexts, metric context or other metadata down to the callback.
+		// - cancellation if the callback potentially does I/O.
 		ControlContext: ssrfSocketControl(ssrfSafe),
 		// see: net.DefaultResolver
 		Resolver: &net.Resolver{


### PR DESCRIPTION
- Use net.Dialer.ControlContext instead of use net.Dialer.Control
  Using Dialer.ControlContext instead of Dialer.Control allows;
   - propagation of logging contexts, metric context or other metadata down to the callback.
   - cancellation if the callback potentially does I/O.
- Fixes: https://github.com/komuw/ong/issues/149
- https://github.com/golang/go/issues/55301