### PR TITLE
issues/249: Include TLS fingerprint in encrypted cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Most recent version is listed first.  
 
 
+## v0.0.46
+- Include TLS fingerprint in encrypted cookies: https://github.com/komuw/ong/pull/250
+
 ## v0.0.45
 - Run all tests in CI: https://github.com/komuw/ong/pull/248
 

--- a/cookie/cookie.go
+++ b/cookie/cookie.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/komuw/ong/cry"
 	"github.com/komuw/ong/internal/clientip"
+	"github.com/komuw/ong/internal/finger"
 )
 
 const (
@@ -146,15 +147,21 @@ func SetEncrypted(
 		// Note: client IP can be spoofed easily and this could lead to issues with their cookies.
 		r,
 	)
+	fingerprint := finger.Get(
+		// might also be spoofed??
+		r,
+	)
 	expires := strconv.Itoa(
 		int(
 			time.Now().UTC().Add(mAge).Unix(),
 		),
 	)
-	combined := ip + expires + value
+	combined := ip + fingerprint + expires + value
 	encryptedEncodedVal := fmt.Sprintf(
-		"%d%s%d%s%s",
+		"%d%s%d%s%d%s%s",
 		len(ip),
+		sep,
+		len(fingerprint),
 		sep,
 		len(expires),
 		sep,
@@ -187,6 +194,7 @@ func GetEncrypted(
 	}
 
 	subs := strings.Split(c.Value, sep)
+	fmt.Println("\t subs: ", subs)
 	if len(subs) != 3 {
 		return nil, errors.New("ong/cookie: invalid cookie")
 	}

--- a/internal/clientip/client_ip.go
+++ b/internal/clientip/client_ip.go
@@ -48,7 +48,7 @@ const (
 )
 
 // Get returns the "real" client IP address.
-// see ong/middleware for docs.
+// See [github.com/komuw/ong/middleware.ClientIP]
 func Get(r *http.Request) string {
 	if vCtx := r.Context().Value(clientIPctxKey); vCtx != nil {
 		if s, ok := vCtx.(string); ok && s != "" {

--- a/internal/finger/finger.go
+++ b/internal/finger/finger.go
@@ -1,10 +1,29 @@
 // Package finger provides(in a best effort manner) a client's TLS fingerprint.
 package finger
 
-import "sync/atomic"
+import (
+	"net/http"
+	"sync/atomic"
+
+	"github.com/komuw/ong/internal/octx"
+)
 
 // Print stores a TLS fingerprint.
 // See [github.com/komuw/ong/middleware.ClientFingerPrint]
 type Print struct {
 	Hash atomic.Pointer[string]
+}
+
+// Get returns the [TLS fingerprint] of the client.
+// See [github.com/komuw/ong/middleware.ClientFingerPrint]
+func Get(r *http.Request) string {
+	ctx := r.Context()
+
+	if vCtx := ctx.Value(octx.FingerPrintCtxKey); vCtx != nil {
+		if s, ok := vCtx.(string); ok {
+			return s
+		}
+	}
+
+	return ""
 }

--- a/internal/finger/finger.go
+++ b/internal/finger/finger.go
@@ -25,5 +25,5 @@ func Get(r *http.Request) string {
 		}
 	}
 
-	return ""
+	return "FingerPrintNotFound"
 }

--- a/middleware/fingerprint.go
+++ b/middleware/fingerprint.go
@@ -35,7 +35,7 @@ func fingerprint(wrappedHandler http.HandlerFunc) http.HandlerFunc {
 }
 
 // ClientFingerPrint returns the [TLS fingerprint] of the client.
-// It is provided on a best-effort basis.
+// It is provided on a best-effort basis. If a fingerprint is not found, it returns a string that has the substring "NotFound" in it.
 // There are different formats/algorithms of fingerprinting, this library(by design) does not subscribe to a particular format or algorithm.
 //
 // [TLS fingerprint]: https://github.com/LeeBrotherston/tls-fingerprinting

--- a/middleware/fingerprint.go
+++ b/middleware/fingerprint.go
@@ -40,13 +40,5 @@ func fingerprint(wrappedHandler http.HandlerFunc) http.HandlerFunc {
 //
 // [TLS fingerprint]: https://github.com/LeeBrotherston/tls-fingerprinting
 func ClientFingerPrint(r *http.Request) string {
-	ctx := r.Context()
-
-	if vCtx := ctx.Value(octx.FingerPrintCtxKey); vCtx != nil {
-		if s, ok := vCtx.(string); ok {
-			return s
-		}
-	}
-
-	return ""
+	return finger.Get(r)
 }

--- a/middleware/ratelimiter_test.go
+++ b/middleware/ratelimiter_test.go
@@ -153,7 +153,7 @@ func TestRl(t *testing.T) {
 			timeTakenToDeliver := time.Now().UTC().Sub(start)
 			effectiveMessageRate := int(float64(msgsDelivered) / timeTakenToDeliver.Seconds())
 
-			attest.Approximately(t, effectiveMessageRate, int(sendRate), 3)
+			attest.Approximately(t, effectiveMessageRate, int(sendRate), 4)
 		}
 
 		{

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -188,7 +188,7 @@ func TestServer(t *testing.T) {
 	t.Run("tls", func(t *testing.T) {
 		t.Parallel()
 
-		port := uint16(65081)
+		port := math.MaxUint16 - uint16(10)
 		uri := "/api"
 		msg := "hello world"
 		mux := mux.New(
@@ -203,9 +203,8 @@ func TestServer(t *testing.T) {
 		)
 
 		go func() {
-			_, _ = createDevCertKey(l)
-			time.Sleep(1 * time.Second)
-			err := Run(mux, DevOpts(l), l)
+			certFile, keyFile := createDevCertKey(l)
+			err := Run(mux, withOpts(port, certFile, keyFile, "", "localhost"), l)
 			attest.Ok(t, err)
 		}()
 
@@ -280,7 +279,7 @@ func TestServer(t *testing.T) {
 	t.Run("concurrency safe", func(t *testing.T) {
 		t.Parallel()
 
-		port := math.MaxUint16 - uint16(3)
+		port := math.MaxUint16 - uint16(12)
 		uri := "/api"
 		msg := "hello world"
 		mux := mux.New(
@@ -343,7 +342,8 @@ func BenchmarkServer(b *testing.B) {
 	l := log.New(&bytes.Buffer{}, 500)(context.Background())
 
 	handler := benchmarkServerHandler("helloWorld")
-	port := math.MaxUint16 - uint16(7)
+	port := math.MaxUint16 - uint16(14)
+
 	go func() {
 		certFile, keyFile := createDevCertKey(l)
 		time.Sleep(1 * time.Second)


### PR DESCRIPTION
**What:**
- This helps to try and mitigate against session replay attacks and session hijacking.
  Two motivating examples:
  (a) CircleCI was hacked[1]. They said; "Our investigation indicates that the malware was able to execute session cookie theft, enabling them to impersonate the targeted employee in a remote location"
  (b) Loom had an incident[2]. They said; "Some our users had their information exposed to other user accounts. A configuration change to our Content Delivery Network (CDN) caused incorrect session cookies to be sent back to our users."
- In both the two cases I do believe that including the client's IP address could have helped mitigate the issue. We already do include user IP addresses in encrypted cookies.
- The problem with client IP is that they can be spoofed[3]
- I do think that embedding TLS fingerprints improves the mitigation even further.
  I'm not alone, John Althouse(one of the authors of JA3 TLS fingerprint hash) says[4] that using ja3 would have made session hijacking difficult in the case of the cirlceCI incident.

**Why:**
- Fixes: https://github.com/komuw/ong/issues/249

**Ref:**
1. https://circleci.com/blog/jan-4-2023-incident-report
2. https://www.loom.com/blog/march-7-incident-update
3. https://adam-p.ca/blog/2022/03/x-forwarded-for/
4. https://twitter.com/4A4133/status/1615103474739429377