### PR TITLE
New log circular buffer

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -225,3 +225,38 @@ func (c *circleBuf) store(r slog.Record) {
 func (c *circleBuf) reset() {
 	c.buf = c.buf[:0]
 }
+
+// ///////////////////////////////
+
+// https://go-review.googlesource.com/c/go/+/478200/3/src/log/slog/internal/benchmarks/handlers.go#121
+type ringBuffer struct {
+	buf     []slog.Record
+	next    int
+	maxSize int
+}
+
+func newRingBufferf(maxSize int) *ringBuffer {
+	if maxSize <= 0 {
+		maxSize = 10
+	}
+
+	r := &ringBuffer{
+		buf:     make([]slog.Record, maxSize),
+		next:    0,
+		maxSize: maxSize,
+	}
+
+	// r.reset() // remove the nils from `make()`
+
+	return r
+}
+
+func (r *ringBuffer) store(a slog.Record) {
+	r.buf[r.next] = a
+	r.next = (r.next + 1) % r.maxSize
+}
+
+func (r *ringBuffer) reset() {
+	r.buf = r.buf[:0]
+	r.next = 0
+}

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	ongErrors "github.com/komuw/ong/errors"
 	"github.com/komuw/ong/internal/octx"
@@ -96,6 +97,29 @@ func TestCircleBuf(t *testing.T) {
 		attest.Equal(t, len(c.buf), 0)
 		attest.Equal(t, cap(c.buf), maxSize)
 	})
+}
+
+var benchmarkCircleBufResult int
+
+func BenchmarkCircleBuf(b *testing.B) {
+	maxN := 0
+	maxSize := 100
+	c := newCirleBuf(maxSize)
+	rec := slog.NewRecord(time.Now(), slog.LevelError, "hello", 0)
+
+	b.StopTimer()
+	b.StartTimer()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		c.store(rec)
+		maxN = n
+	}
+	b.StopTimer()
+
+	// always store the result to a package level variable
+	// so the compiler cannot eliminate the Benchmark itself.
+	benchmarkCircleBufResult = maxN
 }
 
 func TestLogger(t *testing.T) {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -104,7 +104,7 @@ var benchmarkCircleBufResult int
 func BenchmarkCircleBuf(b *testing.B) {
 	maxN := 0
 	maxSize := 100
-	c := newCirleBuf(maxSize)
+	c := newRingBufferf(maxSize)
 	rec := slog.NewRecord(time.Now(), slog.LevelError, "hello", 0)
 
 	b.StopTimer()


### PR DESCRIPTION
taken from https://go-review.googlesource.com/c/go/+/478200/3/src/log/slog/internal/benchmarks/handlers.go#121