### PR TITLE
issues/253: add support for PROXY protocol in clientIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Most recent version is listed first.
 ## v0.0.47
 - Leave http.server.DisableGeneralOptionsHandler at its default value: https://github.com/komuw/ong/pull/255
 - Validate expiry of csrf tokens: https://github.com/komuw/ong/pull/257
+- Add support for PROXY protocol in clientIP: https://github.com/komuw/ong/pull/258
 
 ## v0.0.46
 - Include TLS fingerprint in encrypted cookies: https://github.com/komuw/ong/pull/250

--- a/internal/clientip/client_ip.go
+++ b/internal/clientip/client_ip.go
@@ -85,10 +85,12 @@ func DirectAddress(remoteAddr string) string {
 // This strategy should be used when the given header is added by a trusted reverse proxy.
 // You MUST ensure that this header is not spoofable (as is possible with Akamai's use of
 // True-Client-IP, Fastly's default use of Fastly-Client-IP, and Azure's X-Azure-ClientIP).
-// See the single-IP wiki page for more info: https://github.com/realclientip/realclientip-go/wiki/Single-IP-Headers
+// See the [single-IP wiki] page for more info.
 //
 // The returned IP may contain a zone identifier.
 // If no valid IP can be derived, empty string will be returned.
+//
+// [single-IP wiki]: https://github.com/realclientip/realclientip-go/wiki/Single-IP-Headers
 func SingleIPHeader(headerName string, headers http.Header) string {
 	headerName = http.CanonicalHeaderKey(headerName)
 
@@ -195,6 +197,54 @@ func Rightmost(headers http.Header) string {
 
 	// We failed to find any valid, non-private IP
 	return theIP
+}
+
+// ProxyHeader derives an IP address based off the [PROXY protocol v1].
+//
+// [PROXY protocol v1]: https://www.haproxy.org/download/2.8/doc/proxy-protocol.txt
+func ProxyHeader(headers http.Header) string {
+	s := headers.Get("PROXY")
+
+	if len(s) < 56 {
+		// The maximum line lengths of proxy-protocol line including the CRLF are:
+		// ipv4: 56 chars, ipv6: 104 chars, unknown: 15 chars.
+		//
+		// see: https://www.haproxy.org/download/2.8/doc/proxy-protocol.txt
+		return ""
+	}
+
+	// The proxy protocol line is a single line that ends with a carriage return and line feed ("\r\n"), and has the following form:
+	/*
+		  PROXY_STRING +
+		  single space +
+		  INET_PROTOCOL +
+		  single space +
+		  CLIENT_IP +
+		  single space +
+		  PROXY_IP +
+		  single space +
+		  CLIENT_PORT +
+		  single space +
+		  PROXY_PORT +
+		  "\r\n"
+
+		eg:
+		  PROXY TCP4 198.51.100.22 203.0.113.7 35646 80\r\n
+		  PROXY TCP6 2001:DB8::21f:5bff:febf:ce22:8a2e 2001:DB8::12f:8baa:eafc:ce29:6b2e 35646 80\r\n
+
+		- https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-proxy-protocol.html
+	*/
+
+	s1 := s[11:] // len("PROXY TCP6 ")
+	ipStr := strings.Split(s1, " ")[0]
+
+	ipAddr := goodIPAddr(ipStr)
+	if ipAddr == nil {
+		// The header value is invalid
+		return ""
+	}
+
+	return ipAddr.String()
 }
 
 // goodIPAddr parses IP address and adds a check for unspecified (like "::") and zero-value addresses (like "0.0.0.0").

--- a/internal/clientip/client_ip.go
+++ b/internal/clientip/client_ip.go
@@ -43,6 +43,7 @@ const (
 	errPrefix           = "ong/internal/clientip:"
 	xForwardedForHeader = "X-Forwarded-For"
 	forwardedHeader     = "Forwarded"
+	proxyHeader         = "PROXY"
 	// clientIPctxKey is the name of the context key used to store the client IP address.
 	clientIPctxKey = clientIPcontextKeyType("clientIPcontextKeyType")
 )
@@ -203,7 +204,7 @@ func Rightmost(headers http.Header) string {
 //
 // [PROXY protocol v1]: https://www.haproxy.org/download/2.8/doc/proxy-protocol.txt
 func ProxyHeader(headers http.Header) string {
-	s := headers.Get("PROXY")
+	s := headers.Get(proxyHeader)
 
 	if len(s) < 56 {
 		// The maximum line lengths of proxy-protocol line including the CRLF are:

--- a/internal/clientip/client_ip.go
+++ b/internal/clientip/client_ip.go
@@ -206,9 +206,10 @@ func Rightmost(headers http.Header) string {
 func ProxyHeader(headers http.Header) string {
 	s := headers.Get(proxyHeader)
 
-	if len(s) < 56 {
+	if len(s) <= 15 {
 		// The maximum line lengths of proxy-protocol line including the CRLF are:
 		// ipv4: 56 chars, ipv6: 104 chars, unknown: 15 chars.
+		// Thus any string of length less-than-or-equal-to 15 does not contain a valid client_ip.
 		//
 		// see: https://www.haproxy.org/download/2.8/doc/proxy-protocol.txt
 		return ""

--- a/internal/clientip/client_ip_test.go
+++ b/internal/clientip/client_ip_test.go
@@ -18,8 +18,9 @@ func TestMain(m *testing.M) {
 func TestClientIPstrategy(t *testing.T) {
 	t.Parallel()
 
-	awsMetadataApiPrivateIP := "169.254.169.254" // AWS metadata api IP address.
-	publicIP := "93.184.216.34"                  // example.com IP address
+	awsMetadataApiPrivateIP := "169.254.169.254"       // AWS metadata api IP address.
+	publicIPv4 := "93.184.216.34"                      // example.com IP4 address
+	publicIPv6 := "2606:2800:220:1:248:1893:25c8:1946" // example.com IP6 address
 
 	tests := []struct {
 		name        string
@@ -41,7 +42,7 @@ func TestClientIPstrategy(t *testing.T) {
 			name: "singleIPHeaderStrategy/bad-header",
 			updateReq: func(req *http.Request) string {
 				headerName := xForwardedForHeader
-				req.Header.Add(headerName, publicIP)
+				req.Header.Add(headerName, publicIPv4)
 				return headerName
 			},
 			runStrategy: func(remoteAddr, headerName string, headers http.Header) string {
@@ -69,7 +70,7 @@ func TestClientIPstrategy(t *testing.T) {
 			name: "singleIPHeaderStrategy/not-private-ip",
 			updateReq: func(req *http.Request) string {
 				headerName := "Fly-Client-IP"
-				req.Header.Add(headerName, publicIP)
+				req.Header.Add(headerName, publicIPv4)
 				return headerName
 			},
 			runStrategy: func(remoteAddr, headerName string, headers http.Header) string {
@@ -77,14 +78,14 @@ func TestClientIPstrategy(t *testing.T) {
 			},
 			assert: func(ip string) {
 				attest.NotZero(t, ip)
-				attest.Equal(t, ip, publicIP)
+				attest.Equal(t, ip, publicIPv4)
 			},
 		},
 		{
 			name: "singleIPHeaderStrategy/not-private-ip-with-port",
 			updateReq: func(req *http.Request) string {
 				headerName := "Fly-Client-IP"
-				req.Header.Add(headerName, fmt.Sprintf("%s:%d", publicIP, 9093))
+				req.Header.Add(headerName, fmt.Sprintf("%s:%d", publicIPv4, 9093))
 				return headerName
 			},
 			runStrategy: func(remoteAddr, headerName string, headers http.Header) string {
@@ -92,7 +93,7 @@ func TestClientIPstrategy(t *testing.T) {
 			},
 			assert: func(ip string) {
 				attest.NotZero(t, ip)
-				attest.Equal(t, ip, publicIP)
+				attest.Equal(t, ip, publicIPv4)
 			},
 		},
 
@@ -100,7 +101,7 @@ func TestClientIPstrategy(t *testing.T) {
 			name: "leftmostNonPrivateStrategy/bad-header",
 			updateReq: func(req *http.Request) string {
 				headerName := "Fly-Client-IP"
-				req.Header.Add(headerName, publicIP)
+				req.Header.Add(headerName, publicIPv4)
 				return headerName
 			},
 			runStrategy: func(remoteAddr, headerName string, headers http.Header) string {
@@ -146,7 +147,7 @@ func TestClientIPstrategy(t *testing.T) {
 			name: "leftmostNonPrivateStrategy/not-privateIp-xForwardedForHeader",
 			updateReq: func(req *http.Request) string {
 				headerName := xForwardedForHeader
-				req.Header.Add(headerName, publicIP)
+				req.Header.Add(headerName, publicIPv4)
 				return headerName
 			},
 			runStrategy: func(remoteAddr, headerName string, headers http.Header) string {
@@ -154,7 +155,7 @@ func TestClientIPstrategy(t *testing.T) {
 			},
 			assert: func(ip string) {
 				attest.NotZero(t, ip)
-				attest.Equal(t, ip, publicIP)
+				attest.Equal(t, ip, publicIPv4)
 			},
 		},
 		{
@@ -164,7 +165,7 @@ func TestClientIPstrategy(t *testing.T) {
 				req.Header.Add(
 					headerName,
 					// see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded#transitioning_from_x-forwarded-for_to_forwarded
-					fmt.Sprintf("for=%s", publicIP),
+					fmt.Sprintf("for=%s", publicIPv4),
 				)
 				return headerName
 			},
@@ -173,7 +174,7 @@ func TestClientIPstrategy(t *testing.T) {
 			},
 			assert: func(ip string) {
 				attest.NotZero(t, ip)
-				attest.Equal(t, ip, publicIP)
+				attest.Equal(t, ip, publicIPv4)
 			},
 		},
 
@@ -181,7 +182,7 @@ func TestClientIPstrategy(t *testing.T) {
 			name: "rightmostNonPrivateStrategy/bad-header",
 			updateReq: func(req *http.Request) string {
 				headerName := "Fly-Client-IP"
-				req.Header.Add(headerName, publicIP)
+				req.Header.Add(headerName, publicIPv4)
 				return headerName
 			},
 			runStrategy: func(remoteAddr, headerName string, headers http.Header) string {
@@ -227,7 +228,7 @@ func TestClientIPstrategy(t *testing.T) {
 			name: "rightmostNonPrivateStrategy/not-privateIp-xForwardedForHeader",
 			updateReq: func(req *http.Request) string {
 				headerName := xForwardedForHeader
-				req.Header.Add(headerName, publicIP)
+				req.Header.Add(headerName, publicIPv4)
 				return headerName
 			},
 			runStrategy: func(remoteAddr, headerName string, headers http.Header) string {
@@ -235,7 +236,7 @@ func TestClientIPstrategy(t *testing.T) {
 			},
 			assert: func(ip string) {
 				attest.NotZero(t, ip)
-				attest.Equal(t, ip, publicIP)
+				attest.Equal(t, ip, publicIPv4)
 			},
 		},
 		{
@@ -245,7 +246,7 @@ func TestClientIPstrategy(t *testing.T) {
 				req.Header.Add(
 					headerName,
 					// see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded#transitioning_from_x-forwarded-for_to_forwarded
-					fmt.Sprintf("for=%s", publicIP),
+					fmt.Sprintf("for=%s", publicIPv4),
 				)
 				return headerName
 			},
@@ -254,7 +255,72 @@ func TestClientIPstrategy(t *testing.T) {
 			},
 			assert: func(ip string) {
 				attest.NotZero(t, ip)
-				attest.Equal(t, ip, publicIP)
+				attest.Equal(t, ip, publicIPv4)
+			},
+		},
+
+		{
+			name: "ProxyHeader/empty",
+			updateReq: func(req *http.Request) string {
+				headerName := proxyHeader
+				req.Header.Add(headerName, "")
+				return headerName
+			},
+			runStrategy: func(remoteAddr, headerName string, headers http.Header) string {
+				return ProxyHeader(headers)
+			},
+			assert: func(ip string) {
+				attest.Zero(t, ip)
+			},
+		},
+		{
+			name: "ProxyHeader/unknown",
+			updateReq: func(req *http.Request) string {
+				headerName := proxyHeader
+				req.Header.Add(headerName, "PROXY UNKNOWN\r\n")
+				return headerName
+			},
+			runStrategy: func(remoteAddr, headerName string, headers http.Header) string {
+				return ProxyHeader(headers)
+			},
+			assert: func(ip string) {
+				attest.Zero(t, ip)
+			},
+		},
+		{
+			name: "ProxyHeader/ipv4",
+			updateReq: func(req *http.Request) string {
+				headerName := proxyHeader
+				req.Header.Add(headerName,
+					// https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-proxy-protocol.html
+					fmt.Sprintf("PROXY TCP4 %s 203.0.113.7 35646 80\r\n", publicIPv4),
+				)
+				return headerName
+			},
+			runStrategy: func(remoteAddr, headerName string, headers http.Header) string {
+				return ProxyHeader(headers)
+			},
+			assert: func(ip string) {
+				attest.NotZero(t, ip)
+				attest.Equal(t, ip, publicIPv4)
+			},
+		},
+		{
+			name: "ProxyHeader/ipv6",
+			updateReq: func(req *http.Request) string {
+				headerName := proxyHeader
+				req.Header.Add(headerName,
+					// https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-proxy-protocol.html
+					fmt.Sprintf("PROXY TCP6 %s 2001:DB8::12f:8baa:eafc:ce29:6b2e 35646 80\r\n", publicIPv6),
+				)
+				return headerName
+			},
+			runStrategy: func(remoteAddr, headerName string, headers http.Header) string {
+				return ProxyHeader(headers)
+			},
+			assert: func(ip string) {
+				attest.NotZero(t, ip)
+				attest.Equal(t, ip, publicIPv6)
 			},
 		},
 	}

--- a/middleware/client_ip.go
+++ b/middleware/client_ip.go
@@ -15,18 +15,18 @@ import (
 type ClientIPstrategy string
 
 const (
-	// DirectIpStrategy should be used if the server accepts direct connections, rather than through a proxy.
+	// DirectIpStrategy derives the client IP from [http.Request.RemoteAddr].
+	// It should be used if the server accepts direct connections, rather than through a proxy.
 	//
 	// See the warning in [ClientIP]
 	DirectIpStrategy = ClientIPstrategy("DirectIpStrategy")
 
-	// LeftIpStrategy derives the client IP from the leftmost valid & non-private IP address in the `X-Fowarded-For`/`Forwarded` header.
-	// Note: This MUST NOT be used for security purposes. This IP can be trivially SPOOFED.
+	// LeftIpStrategy derives the client IP from the leftmost valid & non-private IP address in the `X-Fowarded-For` or `Forwarded` header.
 	//
 	// See the warning in [ClientIP]
 	LeftIpStrategy = ClientIPstrategy("LeftIpStrategy")
 
-	// RightIpStrategy derives the client IP from the rightmost valid & non-private IP address in the `X-Fowarded-For`/`Forwarded` header.
+	// RightIpStrategy derives the client IP from the rightmost valid & non-private IP address in the `X-Fowarded-For` or `Forwarded` header.
 	//
 	// See the warning in [ClientIP]
 	RightIpStrategy = ClientIPstrategy("RightIpStrategy")
@@ -34,6 +34,7 @@ const (
 	// ProxyStrategy derives the client IP from the [PROXY protocol v1].
 	// This should be used when your application is behind a TCP proxy that uses the v1 PROXY protocol.
 	//
+	// 	See the warning in [ClientIP]
 	// [PROXY protocol v1]: https://www.haproxy.org/download/2.8/doc/proxy-protocol.txt
 	ProxyStrategy = ClientIPstrategy("ProxyStrategy")
 )

--- a/middleware/client_ip.go
+++ b/middleware/client_ip.go
@@ -49,7 +49,7 @@ func SingleIpStrategy(headerName string) ClientIPstrategy {
 	return ClientIPstrategy(headerName)
 }
 
-// ClientIP returns the "real" client IP address. This will be based on the [ClientIPstrategy] that you choose.
+// ClientIP returns the "real" client IP address. This will be based on the [ClientIPstrategy] that you chose.
 //
 // Warning: This should be used with caution. Clients CAN easily spoof IP addresses.
 // Fetching the "real" client is done in a best-effort basis and can be [grossly inaccurate & precarious].

--- a/middleware/client_ip.go
+++ b/middleware/client_ip.go
@@ -12,7 +12,6 @@ import (
 //
 
 // ClientIPstrategy is a middleware option that describes the strategy to use when fetching the client's IP address.
-// The strategies supported are [DirectIpStrategy], [LeftIpStrategy], [RightIpStrategy] & [SingleIpStrategy]
 type ClientIPstrategy string
 
 const (

--- a/middleware/client_ip.go
+++ b/middleware/client_ip.go
@@ -20,13 +20,13 @@ const (
 	// See the warning in [ClientIP]
 	DirectIpStrategy = ClientIPstrategy("DirectIpStrategy")
 
-	// LeftIpStrategy derives the client IP from the leftmost valid and non-private IP address in the `X-Fowarded-For` or `Forwarded` header.
+	// LeftIpStrategy derives the client IP from the leftmost valid & non-private IP address in the `X-Fowarded-For`/`Forwarded` header.
 	// Note: This MUST NOT be used for security purposes. This IP can be trivially SPOOFED.
 	//
 	// See the warning in [ClientIP]
 	LeftIpStrategy = ClientIPstrategy("LeftIpStrategy")
 
-	// RightIpStrategy derives the client IP from the rightmost valid and non-private IP address in the `X-Fowarded-For` or `Forwarded` header.
+	// RightIpStrategy derives the client IP from the rightmost valid & non-private IP address in the `X-Fowarded-For`/`Forwarded` header.
 	//
 	// See the warning in [ClientIP]
 	RightIpStrategy = ClientIPstrategy("RightIpStrategy")
@@ -40,7 +40,7 @@ const (
 
 // SingleIpStrategy derives the client IP from http header headerName.
 //
-// headerName MUST not be either `X-Forwarded-For` or `Forwarded`.
+// headerName MUST NOT be either `X-Forwarded-For` or `Forwarded`.
 // It can be something like `CF-Connecting-IP`, `Fastly-Client-IP`, `Fly-Client-IP`, etc; depending on your usecase.
 //
 // See the warning in [ClientIP]

--- a/middleware/client_ip.go
+++ b/middleware/client_ip.go
@@ -48,7 +48,7 @@ func SingleIpStrategy(headerName string) ClientIPstrategy {
 	return ClientIPstrategy(headerName)
 }
 
-// ClientIP returns the "real" client IP address. This will be based on the [ClientIPstrategy] that you chose.
+// ClientIP returns the "real" client IP address. This will be based on the [ClientIPstrategy] that you choose.
 //
 // Warning: This should be used with caution. Clients CAN easily spoof IP addresses.
 // Fetching the "real" client is done in a best-effort basis and can be [grossly inaccurate & precarious].

--- a/middleware/client_ip_test.go
+++ b/middleware/client_ip_test.go
@@ -14,6 +14,7 @@ import (
 const (
 	xForwardedForHeader = "X-Forwarded-For"
 	forwardedHeader     = "Forwarded"
+	proxyHeader         = "PROXY"
 )
 
 func someClientIpHandler(msg string) http.HandlerFunc {
@@ -89,6 +90,19 @@ func TestClientIP(t *testing.T) {
 				req: func() *http.Request {
 					r := httptest.NewRequest(http.MethodGet, "/someUri", nil)
 					r.Header.Add(xForwardedForHeader, publicIP)
+					return r
+				},
+				expected: publicIP,
+			},
+			{
+				name:     "ProxyStrategy",
+				strategy: ProxyStrategy,
+				req: func() *http.Request {
+					r := httptest.NewRequest(http.MethodGet, "/someUri", nil)
+					r.Header.Add(proxyHeader,
+						// https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-proxy-protocol.html
+						fmt.Sprintf("PROXY TCP4 %s 203.0.113.7 35646 80\r\n", publicIP),
+					)
 					return r
 				},
 				expected: publicIP,

--- a/middleware/example_test.go
+++ b/middleware/example_test.go
@@ -72,11 +72,8 @@ func ExampleAll() {
 
 	handler := middleware.All(myHandler, opts)
 
-	http.HandleFunc("/", handler)
-	err := http.ListenAndServe(":8080", nil)
-	if err != nil {
-		panic(err)
-	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", handler)
 
 	// Output:
 }

--- a/middleware/example_test.go
+++ b/middleware/example_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/komuw/ong/log"
 	"github.com/komuw/ong/middleware"
+
+	"golang.org/x/exp/slog"
 )
 
 func loginHandler() http.HandlerFunc {
@@ -17,6 +19,15 @@ func loginHandler() http.HandlerFunc {
 		_ = cspNonce // use CSP nonce
 
 		_, _ = fmt.Fprint(w, "welcome to your favorite website.")
+	}
+}
+
+func welcomeHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		csrfToken := middleware.GetCsrfToken(r.Context())
+		_ = csrfToken // use CSRF token
+
+		_, _ = fmt.Fprint(w, "welcome.")
 	}
 }
 
@@ -31,15 +42,6 @@ func Example_getCspNonce() {
 	// Output:
 }
 
-func welcomeHandler() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		csrfToken := middleware.GetCsrfToken(r.Context())
-		_ = csrfToken // use CSRF token
-
-		_, _ = fmt.Fprint(w, "welcome.")
-	}
-}
-
 func Example_getCsrfToken() {
 	l := log.New(os.Stdout, 100)(context.Background())
 	handler := middleware.Get(
@@ -51,7 +53,7 @@ func Example_getCsrfToken() {
 	// Output:
 }
 
-func Example_get() {
+func ExampleGet() {
 	l := log.New(os.Stdout, 100)(context.Background())
 	opts := middleware.WithOpts("example.com", 443, "secretKey", middleware.DirectIpStrategy, l)
 	handler := middleware.Get(loginHandler(), opts)
@@ -60,7 +62,7 @@ func Example_get() {
 	// Output:
 }
 
-func Example_all() {
+func ExampleAll() {
 	l := log.New(os.Stdout, 100)(context.Background())
 	opts := middleware.WithOpts("example.com", 443, "secretKey", middleware.DirectIpStrategy, l)
 
@@ -75,4 +77,21 @@ func Example_all() {
 	if err != nil {
 		panic(err)
 	}
+
+	// Output:
+}
+
+func ExampleWithOpts() {
+	l := slog.New(slog.NewTextHandler(os.Stdout))
+	opts := middleware.WithOpts(
+		"example.com",
+		443,
+		"secretKey",
+		// assuming your application is deployed behind cloudflare.
+		middleware.SingleIpStrategy("CF-Connecting-IP"),
+		l,
+	)
+	_ = opts
+
+	// Output:
 }

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -63,9 +63,8 @@ type Opts struct {
 // It should be unique & kept secret.
 // If it becomes compromised, generate a new one and restart your application using the new one.
 //
-// strategy is the algorithm to use when fetching the client's IP address.
+// strategy is the algorithm to use when fetching the client's IP address; see [ClientIPstrategy].
 // It is important to choose your strategy carefully, see the warning in [ClientIP].
-// The strategies supported are [DirectIpStrategy], [LeftIpStrategy], [RightIpStrategy] & [SingleIpStrategy]
 func New(
 	domain string,
 	httpsPort uint16,

--- a/server/server.go
+++ b/server/server.go
@@ -270,9 +270,9 @@ func sigHandler(
 		sigCaught := <-sigs
 
 		sl := slog.NewLogLogger(logger.Handler(), log.LevelImmediate)
-		sl.Println("server got shutdown signal",
-			"signal", fmt.Sprintf("%v", sigCaught),
-			"shutdownDuration", drainDur.String(),
+		sl.Println("server got shutdown signal.",
+			"signal =", fmt.Sprintf("%v.", sigCaught),
+			"shutdownDuration =", drainDur.String(),
 		)
 
 		err := srv.Shutdown(ctx)


### PR DESCRIPTION
Sometimes a server is placed behind a TCP proxy. 
That server thus never gets the actual client IP.
The proxy protocol[1] fixes that issue by carrying connection information across proxies inside the `PROXY` header.

- Fixes: https://github.com/komuw/ong/issues/253

1. https://www.haproxy.org/download/2.8/doc/proxy-protocol.txt