### PR TITLE
Gracefully handle application termniation in kubernetes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Most recent version is listed first.
 - Add support for PROXY protocol in clientIP: https://github.com/komuw/ong/pull/258
 - Add nilness vet check: https://github.com/komuw/ong/pull/259
 - Add option to restrict size of request bodies: https://github.com/komuw/ong/pull/261
+- Gracefully handle application termniation in kubernetes: https://github.com/komuw/ong/pull/263
 
 ## v0.0.46
 - Include TLS fingerprint in encrypted cookies: https://github.com/komuw/ong/pull/250

--- a/server/server.go
+++ b/server/server.go
@@ -312,7 +312,8 @@ func sigHandler(
 			// (a) & (b) are done concurrently. Thus (b) can occur before (a);
 			// if that is the case; your app will shutdown while k8s is still sending traffic to it.
 			// This sleep here, minimizes the duration of that race condition.
-			// See: https://twitter.com/ProgrammerDude/status/1660238268863066114
+			// - https://twitter.com/ProgrammerDude/status/1660238268863066114
+			// - https://twitter.com/thockin/status/1560398974929973248
 			time.Sleep(drainDur)
 		}
 

--- a/server/server.go
+++ b/server/server.go
@@ -39,6 +39,9 @@ const (
 	// [code]: https://github.com/golang/go/blob/go1.20.3/src/net/http/request.go#L1233-L1235
 	// [code]: https://pkg.go.dev/net/http#Request.ParseForm
 	defaultMaxBodyBytes = uint64(2 * 10 * 1024 * 1024) // 20MB
+
+	// defaultDrainDuration is used to determine the shutdown duration if a custom one is not provided.
+	defaultDrainDuration = 10 * time.Second
 )
 
 type tlsOpts struct {
@@ -376,7 +379,7 @@ func serve(ctx context.Context, srv *http.Server, o Opts, logger *slog.Logger) e
 
 // drainDuration determines how long to wait for the server to shutdown after it has received a shutdown signal.
 func drainDuration(o Opts) time.Duration {
-	dur := 1 * time.Second
+	dur := defaultDrainDuration
 
 	if o.handlerTimeout > dur {
 		dur = o.handlerTimeout
@@ -393,9 +396,6 @@ func drainDuration(o Opts) time.Duration {
 
 	// drainDuration should not take into account o.idleTimeout
 	// because server.Shutdown() already closes all idle connections.
-
-	dur = dur + (10 * time.Second)
-
 	return dur
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -63,7 +63,7 @@ func TestDrainDuration(t *testing.T) {
 			idleTimeout:       120 * time.Second,
 		}
 		got := drainDuration(o)
-		want := handlerTimeout + (10 * time.Second)
+		want := handlerTimeout
 		attest.Equal(t, got, want)
 	})
 
@@ -82,7 +82,26 @@ func TestDrainDuration(t *testing.T) {
 			idleTimeout:       120 * time.Second,
 		}
 		got := drainDuration(o)
-		want := writeTimeout + (10 * time.Second)
+		want := writeTimeout
+		attest.Equal(t, got, want)
+	})
+
+	t.Run("default", func(t *testing.T) {
+		t.Parallel()
+
+		smallDur := 10 * time.Nanosecond
+		o := Opts{
+			port:              65080,
+			host:              "127.0.0.1",
+			network:           "tcp",
+			readHeaderTimeout: smallDur,
+			readTimeout:       smallDur,
+			writeTimeout:      smallDur,
+			handlerTimeout:    smallDur,
+			idleTimeout:       smallDur,
+		}
+		got := drainDuration(o)
+		want := defaultDrainDuration
 		attest.Equal(t, got, want)
 	})
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -45,67 +45,6 @@ func getPort() uint16 {
 // 	goleak.VerifyTestMain(m)
 // }
 
-func TestDrainDuration(t *testing.T) {
-	t.Parallel()
-
-	t.Run("all in same units", func(t *testing.T) {
-		t.Parallel()
-
-		handlerTimeout := 170 * time.Second
-		o := Opts{
-			port:              65080,
-			host:              "127.0.0.1",
-			network:           "tcp",
-			readHeaderTimeout: 1 * time.Second,
-			readTimeout:       1 * time.Second,
-			writeTimeout:      160 * time.Second,
-			handlerTimeout:    handlerTimeout,
-			idleTimeout:       120 * time.Second,
-		}
-		got := drainDuration(o)
-		want := handlerTimeout
-		attest.Equal(t, got, want)
-	})
-
-	t.Run("different units", func(t *testing.T) {
-		t.Parallel()
-
-		writeTimeout := 3 * time.Minute
-		o := Opts{
-			port:              65080,
-			host:              "127.0.0.1",
-			network:           "tcp",
-			readHeaderTimeout: 1 * time.Nanosecond,
-			readTimeout:       1 * time.Minute,
-			writeTimeout:      writeTimeout,
-			handlerTimeout:    170 * time.Millisecond,
-			idleTimeout:       120 * time.Second,
-		}
-		got := drainDuration(o)
-		want := writeTimeout
-		attest.Equal(t, got, want)
-	})
-
-	t.Run("default", func(t *testing.T) {
-		t.Parallel()
-
-		smallDur := 10 * time.Nanosecond
-		o := Opts{
-			port:              65080,
-			host:              "127.0.0.1",
-			network:           "tcp",
-			readHeaderTimeout: smallDur,
-			readTimeout:       smallDur,
-			writeTimeout:      smallDur,
-			handlerTimeout:    smallDur,
-			idleTimeout:       smallDur,
-		}
-		got := drainDuration(o)
-		want := defaultDrainDuration
-		attest.Equal(t, got, want)
-	})
-}
-
 func TestOpts(t *testing.T) {
 	t.Parallel()
 
@@ -124,6 +63,7 @@ func TestOpts(t *testing.T) {
 			writeTimeout:      3 * time.Second,
 			handlerTimeout:    13 * time.Second,
 			idleTimeout:       113 * time.Second,
+			drainTimeout:      defaultDrainDuration,
 			serverPort:        ":65081",
 			serverAddress:     "127.0.0.1:65081",
 			httpPort:          ":65080",
@@ -152,6 +92,7 @@ func TestOpts(t *testing.T) {
 			writeTimeout:      3 * time.Second,
 			handlerTimeout:    13 * time.Second,
 			idleTimeout:       113 * time.Second,
+			drainTimeout:      defaultDrainDuration,
 			serverPort:        ":80",
 			serverAddress:     "0.0.0.0:80",
 			httpPort:          ":79",
@@ -179,6 +120,7 @@ func TestOpts(t *testing.T) {
 			writeTimeout:      3 * time.Second,
 			handlerTimeout:    13 * time.Second,
 			idleTimeout:       113 * time.Second,
+			drainTimeout:      defaultDrainDuration,
 			tls: tlsOpts{
 				certFile: "/tmp/ong_dev_certificate.pem",
 				keyFile:  "/tmp/ong_dev_key.pem",


### PR DESCRIPTION
Gracefully handle application termniation in kubernetes.
If your app is running in kubernetes(k8s), if a pod is deleted;
(a) it gets deleted from service endpoints.
(b) it receives a SIGTERM from kubelet.
(a) & (b) are done concurrently. Thus (b) can occur before (a);
If that is the case; your app will shutdown while k8s is still sending traffic to it.

We add a sleep before calling server.Shutdown to try and minimize the duration of that race condition.

1. https://twitter.com/thockin/status/1560398974929973248
2. https://twitter.com/ProgrammerDude/status/1660238268863066114