### PR TITLE
issues/267: add mux Resolve function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Most recent version is listed first.  
 
 
+# v0.0.49
+- Add mux Resolve function: https://github.com/komuw/ong/pull/268
+
 ## v0.0.48
 - Change attest import path: https://github.com/komuw/ong/pull/265
 

--- a/mux/example_test.go
+++ b/mux/example_test.go
@@ -51,3 +51,26 @@ func ExampleMux() {
 		panic(err)
 	}
 }
+
+func ExampleMux_Resolve() {
+	l := log.New(os.Stdout, 1000)(context.Background())
+	mux := mux.New(
+		l,
+		middleware.WithOpts("localhost", 8080, "secretKey", middleware.DirectIpStrategy, l),
+		nil,
+		mux.NewRoute(
+			"login/",
+			mux.MethodGet,
+			LoginHandler(),
+		),
+		mux.NewRoute(
+			"/books/:author",
+			mux.MethodAll,
+			BooksByAuthorHandler(),
+		),
+	)
+
+	fmt.Println(mux.Resolve("nonExistentPath"))
+	fmt.Println(mux.Resolve("login/"))
+	fmt.Println(mux.Resolve("https://localhost/books/SidneySheldon"))
+}

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -106,8 +106,8 @@ func New(l *slog.Logger, opt middleware.Opts, notFoundHandler http.HandlerFunc, 
 	return m
 }
 
-func (m Mux) addPattern(method, pattern string, originalHandler, wrappedHandler http.HandlerFunc) {
-	m.router.handle(method, pattern, originalHandler, wrappedHandler)
+func (m Mux) addPattern(method, pattern string, originalHandler, wrappingHandler http.HandlerFunc) {
+	m.router.handle(method, pattern, originalHandler, wrappingHandler)
 }
 
 // ServeHTTP implements a http.Handler

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -116,7 +116,9 @@ func (m Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	m.router.serveHTTP(w, r)
 }
 
-// Resolve resolves a URL path to the corresponding http handler.
+// Resolve resolves a URL path to its corresponding [Route] and hence http handler.
+// If no corresponding route/handler is found, a zero value [Route] is returned.
+//
 // It is not intended for use in production setting, it is more of a dev/debugging tool.
 // It is inspired by django's [resolve] url utility.
 // [resolve]: https://docs.djangoproject.com/en/4.2/ref/urlresolvers/#django.urls.resolve
@@ -130,12 +132,7 @@ func (m Mux) Resolve(path string) Route {
 		}
 	}
 
-	return Route{
-		method:          "unknown",
-		pattern:         "unknown",
-		segments:        []string{"unknown"},
-		originalHandler: m.router.notFoundHandler,
-	}
+	return Route{}
 }
 
 // Param gets the path/url parameter from the specified Context.

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -132,7 +132,7 @@ func (m Mux) Resolve(path string) Route {
 	}
 
 	{
-		// TODO: unify this logic with that found in `router.serveHTTP`
+		// todo: unify this logic with that found in `router.serveHTTP`
 		segs := pathSegments(u.Path)
 		for _, rt := range m.router.routes {
 			if _, ok := rt.match(context.Background(), segs); ok {

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -4,6 +4,7 @@ package mux
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/komuw/ong/middleware"
@@ -124,7 +125,14 @@ func (m Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // [resolve]: https://docs.djangoproject.com/en/4.2/ref/urlresolvers/#django.urls.resolve
 func (m Mux) Resolve(path string) Route {
 	// TODO: unify this logic with that found in `router.serveHTTP`
-	segs := pathSegments(path)
+	var zero = Route{}
+
+	u, err := url.Parse(path)
+	if err != nil {
+		return zero
+	}
+
+	segs := pathSegments(u.Path)
 	for _, rt := range m.router.routes {
 		if _, ok := rt.match(context.Background(), segs); ok {
 			return rt
@@ -132,7 +140,7 @@ func (m Mux) Resolve(path string) Route {
 		}
 	}
 
-	return Route{}
+	return zero
 }
 
 // Param gets the path/url parameter from the specified Context.

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -124,7 +124,6 @@ func (m Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // It is inspired by django's [resolve] url utility.
 // [resolve]: https://docs.djangoproject.com/en/4.2/ref/urlresolvers/#django.urls.resolve
 func (m Mux) Resolve(path string) Route {
-	// TODO: unify this logic with that found in `router.serveHTTP`
 	var zero = Route{}
 
 	u, err := url.Parse(path)
@@ -132,11 +131,14 @@ func (m Mux) Resolve(path string) Route {
 		return zero
 	}
 
-	segs := pathSegments(u.Path)
-	for _, rt := range m.router.routes {
-		if _, ok := rt.match(context.Background(), segs); ok {
-			return rt
+	{
+		// TODO: unify this logic with that found in `router.serveHTTP`
+		segs := pathSegments(u.Path)
+		for _, rt := range m.router.routes {
+			if _, ok := rt.match(context.Background(), segs); ok {
+				return rt
 
+			}
 		}
 	}
 

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -124,7 +124,7 @@ func (m Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // It is inspired by django's [resolve] url utility.
 // [resolve]: https://docs.djangoproject.com/en/4.2/ref/urlresolvers/#django.urls.resolve
 func (m Mux) Resolve(path string) Route {
-	var zero = Route{}
+	zero := Route{}
 
 	u, err := url.Parse(path)
 	if err != nil {
@@ -137,7 +137,6 @@ func (m Mux) Resolve(path string) Route {
 		for _, rt := range m.router.routes {
 			if _, ok := rt.match(context.Background(), segs); ok {
 				return rt
-
 			}
 		}
 	}

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -43,7 +43,7 @@ func NewRoute(
 	return Route{
 		method:          method,
 		pattern:         pattern,
-		segs:            pathSegments(pattern),
+		segments:        pathSegments(pattern),
 		originalHandler: handler,
 	}
 }
@@ -120,17 +120,22 @@ func (m Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // It is not intended for use in production setting, it is more of a dev/debugging tool.
 // It is inspired by django's [resolve] url utility.
 // [resolve]: https://docs.djangoproject.com/en/4.2/ref/urlresolvers/#django.urls.resolve
-func (m Mux) Resolve(path string) http.HandlerFunc {
+func (m Mux) Resolve(path string) Route {
 	// TODO: unify this logic with that found in `router.serveHTTP`
 	segs := pathSegments(path)
 	for _, rt := range m.router.routes {
 		if _, ok := rt.match(context.Background(), segs); ok {
-			return rt.wrappedHandler
+			return rt
 
 		}
 	}
 
-	return m.router.notFoundHandler
+	return Route{
+		method:          "unknown",
+		pattern:         "unknown",
+		segments:        []string{"unknown"},
+		originalHandler: m.router.notFoundHandler,
+	}
 }
 
 // Param gets the path/url parameter from the specified Context.

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -120,7 +120,7 @@ func (m Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // Resolve resolves a URL path to its corresponding [Route] and hence http handler.
 // If no corresponding route/handler is found, a zero value [Route] is returned.
 //
-// It is not intended for use in production setting, it is more of a dev/debugging tool.
+// It is not intended for use in production settings, it is more of a dev/debugging tool.
 // It is inspired by django's [resolve] url utility.
 // [resolve]: https://docs.djangoproject.com/en/4.2/ref/urlresolvers/#django.urls.resolve
 func (m Mux) Resolve(path string) Route {

--- a/mux/mux_test.go
+++ b/mux/mux_test.go
@@ -240,8 +240,8 @@ func TestMux(t *testing.T) {
 		h := mux.Resolve("api")
 		fmt.Println(h)
 		attest.Equal(t, h.method, MethodGet)
-		attest.Equal(t, h.originalHandler, expectedHandler)
-		attest.Subsequence(t, h.String(), "api")
+		attest.Equal(t, h.pattern, "/api/")
+		attest.Subsequence(t, h.String(), "ong/mux/mux_test.go:26") // location where `someMuxHandler` is declared.
 
 	})
 }

--- a/mux/mux_test.go
+++ b/mux/mux_test.go
@@ -34,6 +34,13 @@ func thisIsAnotherMuxHandler() http.HandlerFunc {
 	}
 }
 
+func checkAgeHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		age := Param(r.Context(), "age")
+		_, _ = fmt.Fprintf(w, "Age is %s", age)
+	}
+}
+
 func TestMain(m *testing.M) {
 	// call flag.Parse() here if TestMain uses flags
 	goleak.VerifyTestMain(m)
@@ -235,6 +242,11 @@ func TestMux(t *testing.T) {
 				MethodGet,
 				expectedHandler,
 			),
+			NewRoute(
+				"check/:age/",
+				MethodAll,
+				checkAgeHandler(),
+			),
 		)
 
 		tests := []struct {
@@ -257,6 +269,13 @@ func TestMux(t *testing.T) {
 				"",
 				"",
 				"",
+			},
+			{
+				"url with param",
+				"check/2625",
+				"/check/:age/",
+				MethodAll,
+				"ong/mux/mux_test.go:38", // location where `checkAgeHandler` is declared.
 			},
 		}
 

--- a/mux/mux_test.go
+++ b/mux/mux_test.go
@@ -257,8 +257,29 @@ func TestMux(t *testing.T) {
 			stackPath string
 		}{
 			{
-				"success",
+				"success with no slashes",
 				"api",
+				"/api/",
+				MethodGet,
+				"ong/mux/mux_test.go:26", // location where `someMuxHandler` is declared.
+			},
+			{
+				"success with prefix slash",
+				"/api",
+				"/api/",
+				MethodGet,
+				"ong/mux/mux_test.go:26", // location where `someMuxHandler` is declared.
+			},
+			{
+				"success with suffix slash",
+				"api/",
+				"/api/",
+				MethodGet,
+				"ong/mux/mux_test.go:26", // location where `someMuxHandler` is declared.
+			},
+			{
+				"success with all slashes",
+				"/api/",
 				"/api/",
 				MethodGet,
 				"ong/mux/mux_test.go:26", // location where `someMuxHandler` is declared.
@@ -273,6 +294,13 @@ func TestMux(t *testing.T) {
 			{
 				"url with param",
 				"check/2625",
+				"/check/:age/",
+				MethodAll,
+				"ong/mux/mux_test.go:38", // location where `checkAgeHandler` is declared.
+			},
+			{
+				"url with domain name",
+				"https://localhost/check/2625",
 				"/check/:age/",
 				MethodAll,
 				"ong/mux/mux_test.go:38", // location where `checkAgeHandler` is declared.

--- a/mux/mux_test.go
+++ b/mux/mux_test.go
@@ -314,7 +314,6 @@ func TestMux(t *testing.T) {
 				t.Parallel()
 
 				rt := mux.Resolve(tt.path)
-				fmt.Println(tt.path, " : ", rt) // TODO: remove.
 				attest.Equal(t, rt.method, tt.method)
 				attest.Equal(t, rt.pattern, tt.pattern)
 				attest.Subsequence(t, rt.String(), tt.stackPath)

--- a/mux/mux_test.go
+++ b/mux/mux_test.go
@@ -237,11 +237,40 @@ func TestMux(t *testing.T) {
 			),
 		)
 
-		h := mux.Resolve("api")
-		fmt.Println(h)
-		attest.Equal(t, h.method, MethodGet)
-		attest.Equal(t, h.pattern, "/api/")
-		attest.Subsequence(t, h.String(), "ong/mux/mux_test.go:26") // location where `someMuxHandler` is declared.
+		tests := []struct {
+			name      string
+			path      string
+			pattern   string
+			method    string
+			stackPath string
+		}{
+			{
+				"success",
+				"api",
+				"/api/",
+				MethodGet,
+				"ong/mux/mux_test.go:26", // location where `someMuxHandler` is declared.
+			},
+			{
+				"failure",
+				"/",
+				"",
+				"",
+				"",
+			},
+		}
+
+		for _, tt := range tests {
+			tt := tt
+
+			t.Run(tt.name, func(t *testing.T) {
+				rt := mux.Resolve(tt.path)
+				fmt.Println(tt.path, " : ", rt) // TODO: remove.
+				attest.Equal(t, rt.method, tt.method)
+				attest.Equal(t, rt.pattern, tt.pattern)
+				attest.Subsequence(t, rt.String(), tt.stackPath)
+			})
+		}
 
 	})
 }

--- a/mux/mux_test.go
+++ b/mux/mux_test.go
@@ -283,6 +283,8 @@ func TestMux(t *testing.T) {
 			tt := tt
 
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
 				rt := mux.Resolve(tt.path)
 				fmt.Println(tt.path, " : ", rt) // TODO: remove.
 				attest.Equal(t, rt.method, tt.method)

--- a/mux/mux_test.go
+++ b/mux/mux_test.go
@@ -28,9 +28,9 @@ func someMuxHandler(msg string) http.HandlerFunc {
 	}
 }
 
-func thisIsAnitherMuxHandler() http.HandlerFunc {
+func thisIsAnotherMuxHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "thisIsAnitherMuxHandler")
+		fmt.Fprint(w, "thisIsAnotherMuxHandler")
 	}
 }
 
@@ -201,7 +201,7 @@ func TestMux(t *testing.T) {
 			attest.Subsequence(t, rStr, uri2)
 			attest.Subsequence(t, rStr, method)
 			attest.Subsequence(t, rStr, "ong/mux/mux_test.go:26") // location where `someMuxHandler` is declared.
-			attest.Subsequence(t, rStr, "ong/mux/mux_test.go:32") // location where `thisIsAnitherMuxHandler` is declared.
+			attest.Subsequence(t, rStr, "ong/mux/mux_test.go:32") // location where `thisIsAnotherMuxHandler` is declared.
 		}()
 
 		_ = New(
@@ -216,7 +216,7 @@ func TestMux(t *testing.T) {
 			NewRoute(
 				uri2,
 				method,
-				thisIsAnitherMuxHandler(),
+				thisIsAnotherMuxHandler(),
 			),
 		)
 	})
@@ -225,6 +225,7 @@ func TestMux(t *testing.T) {
 		t.Parallel()
 
 		msg := "hello world"
+		expectedHandler := someMuxHandler(msg)
 		mux := New(
 			l,
 			middleware.WithOpts("localhost", 443, getSecretKey(), middleware.DirectIpStrategy, l),
@@ -232,13 +233,16 @@ func TestMux(t *testing.T) {
 			NewRoute(
 				"/api",
 				MethodGet,
-				someMuxHandler(msg),
+				expectedHandler,
 			),
 		)
 
 		h := mux.Resolve("api")
-		fmt.Println("\n\t handler: ", h)
-		fmt.Println("\n\t handler: ", getfunc(h))
+		fmt.Println(h)
+		attest.Equal(t, h.method, MethodGet)
+		attest.Equal(t, h.originalHandler, expectedHandler)
+		attest.Subsequence(t, h.String(), "api")
+
 	})
 }
 

--- a/mux/mux_test.go
+++ b/mux/mux_test.go
@@ -320,7 +320,6 @@ func TestMux(t *testing.T) {
 				attest.Subsequence(t, rt.String(), tt.stackPath)
 			})
 		}
-
 	})
 }
 

--- a/mux/mux_test.go
+++ b/mux/mux_test.go
@@ -220,6 +220,26 @@ func TestMux(t *testing.T) {
 			),
 		)
 	})
+
+	t.Run("resolve url", func(t *testing.T) {
+		t.Parallel()
+
+		msg := "hello world"
+		mux := New(
+			l,
+			middleware.WithOpts("localhost", 443, getSecretKey(), middleware.DirectIpStrategy, l),
+			nil,
+			NewRoute(
+				"/api",
+				MethodGet,
+				someMuxHandler(msg),
+			),
+		)
+
+		h := mux.Resolve("api")
+		fmt.Println("\n\t handler: ", h)
+		fmt.Println("\n\t handler: ", getfunc(h))
+	})
 }
 
 func getManyRoutes() []Route {

--- a/mux/route.go
+++ b/mux/route.go
@@ -22,7 +22,7 @@ type muxContextKey string
 type Route struct {
 	method          string
 	pattern         string
-	segs            []string
+	segments        []string
 	originalHandler http.HandlerFunc // This is only needed to enhance the debug/panic message when conflicting routes are detected.
 	wrappedHandler  http.HandlerFunc
 }
@@ -32,17 +32,17 @@ func (r Route) String() string {
 Route{
   method: %s,
   pattern: %s,
-  segs: %s,
+  segments: %s,
   originalHandler: %s,
   wrappedHandler: %s,
-}`, r.method, r.pattern, r.segs, getfunc(r.originalHandler), getfunc(r.wrappedHandler))
+}`, r.method, r.pattern, r.segments, getfunc(r.originalHandler), getfunc(r.wrappedHandler))
 }
 
 func (r Route) match(ctx context.Context, segs []string) (context.Context, bool) {
-	if len(segs) > len(r.segs) {
+	if len(segs) > len(r.segments) {
 		return nil, false
 	}
-	for i, seg := range r.segs {
+	for i, seg := range r.segments {
 		if i > len(segs)-1 {
 			return nil, false
 		}
@@ -102,9 +102,9 @@ func (r *router) handle(method, pattern string, originalHandler, wrappedHandler 
 	r.detectConflict(method, pattern, originalHandler)
 
 	rt := Route{
-		method:          strings.ToLower(method),
+		method:          strings.ToUpper(method),
 		pattern:         pattern,
-		segs:            pathSegments(pattern),
+		segments:        pathSegments(pattern),
 		originalHandler: originalHandler,
 		wrappedHandler:  wrappedHandler,
 	}
@@ -146,7 +146,7 @@ func (r *router) detectConflict(method, pattern string, originalHandler http.Han
 
 	incomingSegments := pathSegments(pattern)
 	for _, rt := range r.routes {
-		existingSegments := rt.segs
+		existingSegments := rt.segments
 		sameLen := len(incomingSegments) == len(existingSegments)
 		if !sameLen {
 			// no conflict
@@ -167,7 +167,7 @@ already exists and would conflict.`,
 			pattern,
 			strings.ToUpper(method),
 			getfunc(originalHandler),
-			path.Join(rt.segs...),
+			path.Join(rt.segments...),
 			strings.ToUpper(rt.method),
 			getfunc(rt.originalHandler),
 		)

--- a/mux/route.go
+++ b/mux/route.go
@@ -186,7 +186,7 @@ already exists and would conflict.`,
 	}
 }
 
-func getfunc(handler interface{}) string {
+func getfunc(handler http.Handler) string {
 	fn := runtime.FuncForPC(reflect.ValueOf(handler).Pointer())
 	file, line := fn.FileLine(fn.Entry())
 	return fmt.Sprintf("%s - %s:%d", fn.Name(), file, line)

--- a/mux/route.go
+++ b/mux/route.go
@@ -28,6 +28,15 @@ type Route struct {
 }
 
 func (r Route) String() string {
+	originHandler := ""
+	if r.originalHandler != nil {
+		originHandler = getfunc(r.originalHandler)
+	}
+	wrappedHandler := ""
+	if r.wrappedHandler != nil {
+		wrappedHandler = getfunc(r.wrappedHandler)
+	}
+
 	return fmt.Sprintf(`
 Route{
   method: %s,
@@ -35,7 +44,7 @@ Route{
   segments: %s,
   originalHandler: %s,
   wrappedHandler: %s,
-}`, r.method, r.pattern, r.segments, getfunc(r.originalHandler), getfunc(r.wrappedHandler))
+}`, r.method, r.pattern, r.segments, originHandler, wrappedHandler)
 }
 
 func (r Route) match(ctx context.Context, segs []string) (context.Context, bool) {


### PR DESCRIPTION
What:
- Add mux Resolve function
- Imagine a customer calls and says they tried to access the url `https://localhost/check/888`, they expected to see a photo of a shark instead they saw a photo of an egg. How do you know which code/handler you should go look at, out of 10_000 handlers?
-  It is inspired by django's resolve url utility[3].

Why:
1. Fixes: https://github.com/komuw/ong/issues/267
2. This enhances debugging.
3. https://docs.djangoproject.com/en/4.2/ref/urlresolvers/#django.urls.resolve
