### PR TITLE
issues/260: Add protection against DNS rebinding attacks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Most recent version is listed first.
 
 # v0.0.52
 - Bugfix; match number of log arguments: https://github.com/komuw/ong/pull/275
+- Add protection against DNS rebinding attacks: https://github.com/komuw/ong/pull/276
 
 # v0.0.51
 - Add a http timeout when calling ACME for certificates: https://github.com/komuw/ong/pull/272

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -77,7 +77,7 @@ func New(
 	l *slog.Logger,
 ) Opts {
 	if _, err := idna.Registration.ToASCII(domain); err != nil {
-		panic(err)
+		panic(fmt.Errorf("ong/middleware: domain is invalid: %w", err))
 	}
 
 	return Opts{

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 
 	"golang.org/x/exp/slog"
+	"golang.org/x/net/idna"
 )
 
 // ongMiddlewareErrorHeader is a http header that is set by Ong
@@ -50,7 +51,7 @@ type Opts struct {
 
 // New returns a new Opts.
 //
-// domain is the domain name of your website.
+// domain is the domain name of your website. New panics if domain is invalid.
 //
 // httpsPort is the tls port where http requests will be redirected to.
 //
@@ -75,6 +76,10 @@ func New(
 	strategy ClientIPstrategy,
 	l *slog.Logger,
 ) Opts {
+	if _, err := idna.Registration.ToASCII(domain); err != nil {
+		panic(err)
+	}
+
 	return Opts{
 		domain:         domain,
 		httpsPort:      httpsPort,

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 
 	"github.com/komuw/ong/log"
-
 	"go.akshayshah.org/attest"
 	"go.uber.org/goleak"
+	"golang.org/x/exp/slog"
 )
 
 func someMiddlewareTestHandler(msg string) http.HandlerFunc {
@@ -404,4 +404,49 @@ func BenchmarkAllMiddlewares(b *testing.B) {
 	// always store the result to a package level variable
 	// so the compiler cannot eliminate the Benchmark itself.
 	resultBenchmarkAllMiddlewares = r
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		domain      string
+		expectPanic bool
+	}{
+		// Some of them are taken from; https://github.com/golang/go/blob/go1.20.5/src/net/dnsname_test.go#L19-L34
+		{
+			name:        "good domain",
+			domain:      "localhost",
+			expectPanic: false,
+		},
+		{
+			name:        "good domain B",
+			domain:      "foo.com",
+			expectPanic: false,
+		},
+		{
+			name:        "good domain C",
+			domain:      "bar.foo.com",
+			expectPanic: false,
+		},
+		{
+			name:        "bad domain",
+			domain:      "a.b-.com",
+			expectPanic: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.expectPanic {
+				attest.Panics(t, func() {
+					New(tt.domain, 443, nil, nil, nil, "secretKey", DirectIpStrategy, slog.Default())
+				})
+			} else {
+				New(tt.domain, 443, nil, nil, nil, "secretKey", DirectIpStrategy, slog.Default())
+			}
+		})
+	}
 }

--- a/middleware/redirect.go
+++ b/middleware/redirect.go
@@ -63,7 +63,7 @@ func httpsRedirector(wrappedHandler http.Handler, httpsPort uint16, domain strin
 		{ // 3. DNS rebinding attack protection.
 			if !strings.Contains(host, domain) {
 				// drop request
-				err := fmt.Errorf("ong/middleware: the HOST http header is unexpected")
+				err := fmt.Errorf("ong/middleware: the HOST http header has an unexpected value")
 				w.Header().Set(ongMiddlewareErrorHeader, err.Error())
 				http.Error(
 					w,

--- a/middleware/redirect.go
+++ b/middleware/redirect.go
@@ -14,6 +14,8 @@ import (
 // httpsPort is the tls port where http requests will be redirected to.
 func httpsRedirector(wrappedHandler http.Handler, httpsPort uint16, domain string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		host := r.Host
+
 		isTls := strings.EqualFold(r.URL.Scheme, "https") || r.TLS != nil
 		if !isTls {
 			url := r.URL
@@ -28,7 +30,7 @@ func httpsRedirector(wrappedHandler http.Handler, httpsPort uint16, domain strin
 		// A Host header field must be sent in all HTTP/1.1 request messages.
 		// Thus we expect `r.Host[0]` to always have a value.
 		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
-		isHostBareIP := unicode.IsDigit(rune(r.Host[0]))
+		isHostBareIP := unicode.IsDigit(rune(host[0]))
 		if isHostBareIP {
 			/*
 				the request has tried to access us via an IP address, redirect them to our domain.
@@ -42,7 +44,7 @@ func httpsRedirector(wrappedHandler http.Handler, httpsPort uint16, domain strin
 			*/
 			url := r.URL
 			url.Scheme = "https"
-			_, port, err := net.SplitHostPort(r.Host)
+			_, port, err := net.SplitHostPort(host)
 			if err != nil {
 				port = fmt.Sprint(httpsPort)
 			}

--- a/middleware/redirect.go
+++ b/middleware/redirect.go
@@ -17,7 +17,7 @@ import (
 // [DNS rebinding]: https://en.wikipedia.org/wiki/DNS_rebinding
 func httpsRedirector(wrappedHandler http.Handler, httpsPort uint16, domain string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		{ // http -> https redirect.
+		{ // 1. http -> https redirect.
 			isTls := strings.EqualFold(r.URL.Scheme, "https") || r.TLS != nil
 			if !isTls {
 				url := r.URL
@@ -30,7 +30,7 @@ func httpsRedirector(wrappedHandler http.Handler, httpsPort uint16, domain strin
 			}
 		}
 
-		{ // bareIP -> https redirect.
+		{ // 2. bareIP -> https redirect.
 			// A Host header field must be sent in all HTTP/1.1 request messages.
 			// Thus we expect `r.Host[0]` to always have a value.
 			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
@@ -58,6 +58,9 @@ func httpsRedirector(wrappedHandler http.Handler, httpsPort uint16, domain strin
 				http.Redirect(w, r, path, http.StatusPermanentRedirect)
 				return
 			}
+		}
+
+		{ // 3. DNS rebinding attack protection.
 		}
 
 		wrappedHandler.ServeHTTP(w, r)

--- a/middleware/redirect.go
+++ b/middleware/redirect.go
@@ -14,8 +14,6 @@ import (
 // httpsPort is the tls port where http requests will be redirected to.
 func httpsRedirector(wrappedHandler http.Handler, httpsPort uint16, domain string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		host := r.Host
-
 		isTls := strings.EqualFold(r.URL.Scheme, "https") || r.TLS != nil
 		if !isTls {
 			url := r.URL
@@ -30,6 +28,7 @@ func httpsRedirector(wrappedHandler http.Handler, httpsPort uint16, domain strin
 		// A Host header field must be sent in all HTTP/1.1 request messages.
 		// Thus we expect `r.Host[0]` to always have a value.
 		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
+		host := r.Host
 		isHostBareIP := unicode.IsDigit(rune(host[0]))
 		if isHostBareIP {
 			/*

--- a/middleware/redirect_test.go
+++ b/middleware/redirect_test.go
@@ -269,6 +269,12 @@ func TestHttpsRedirector(t *testing.T) {
 				expectedCode: http.StatusOK,
 				expectedMsg:  msg,
 			},
+			{
+				name:         "bad host",
+				host:         "example.com",
+				expectedCode: http.StatusBadRequest,
+				expectedMsg:  "has an unexpected value",
+			},
 		}
 		for _, tt := range tests {
 			tt := tt

--- a/middleware/redirect_test.go
+++ b/middleware/redirect_test.go
@@ -237,6 +237,54 @@ func TestHttpsRedirector(t *testing.T) {
 		}
 	})
 
+	t.Run("dns rebinding protection", func(t *testing.T) {
+		t.Parallel()
+
+		msg := "hello world"
+		port := uint16(443)
+		domain := "localhost"
+		wrappedHandler := httpsRedirector(someHttpsRedirectorHandler(msg), port, domain)
+		ts := httptest.NewTLSServer(
+			wrappedHandler,
+		)
+		t.Cleanup(func() {
+			ts.Close()
+		})
+
+		tests := []struct {
+			name string
+			host string
+		}{
+			{
+				name: "good host",
+				host: domain,
+			},
+		}
+		for _, tt := range tests {
+			tt := tt
+			_ = tt
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+				attest.Ok(t, err)
+				req.Header.Set("Host", tt.host)
+				req.Host = tt.host
+
+				res, err := client.Do(req)
+				attest.Ok(t, err)
+
+				rb, err := io.ReadAll(res.Body)
+				attest.Ok(t, err)
+				defer res.Body.Close()
+
+				attest.Equal(t, res.StatusCode, http.StatusOK)
+				attest.Zero(t, res.Header.Get(locationHeader))
+				attest.Equal(t, string(rb), msg)
+			})
+		}
+	})
+
 	t.Run("concurrency safe", func(t *testing.T) {
 		t.Parallel()
 

--- a/middleware/redirect_test.go
+++ b/middleware/redirect_test.go
@@ -252,16 +252,22 @@ func TestHttpsRedirector(t *testing.T) {
 		})
 
 		tests := []struct {
-			name string
-			host string
+			name         string
+			host         string
+			expectedCode int
+			expectedMsg  string
 		}{
 			{
-				name: "good host",
-				host: domain,
+				name:         "good host",
+				host:         domain,
+				expectedCode: http.StatusOK,
+				expectedMsg:  msg,
 			},
 			{
-				name: "good subdomain",
-				host: "subdomain." + domain,
+				name:         "good subdomain",
+				host:         "subdomain." + domain,
+				expectedCode: http.StatusOK,
+				expectedMsg:  msg,
 			},
 		}
 		for _, tt := range tests {
@@ -282,9 +288,9 @@ func TestHttpsRedirector(t *testing.T) {
 				attest.Ok(t, err)
 				defer res.Body.Close()
 
-				attest.Equal(t, res.StatusCode, http.StatusOK)
+				attest.Equal(t, res.StatusCode, tt.expectedCode)
 				attest.Zero(t, res.Header.Get(locationHeader))
-				attest.Equal(t, string(rb), msg)
+				attest.Subsequence(t, string(rb), tt.expectedMsg)
 			})
 		}
 	})

--- a/middleware/redirect_test.go
+++ b/middleware/redirect_test.go
@@ -259,6 +259,10 @@ func TestHttpsRedirector(t *testing.T) {
 				name: "good host",
 				host: domain,
 			},
+			{
+				name: "good subdomain",
+				host: "subdomain." + domain,
+			},
 		}
 		for _, tt := range tests {
 			tt := tt


### PR DESCRIPTION
- DNS rebinding[2] is a method of manipulating resolution of domain names that is commonly used as a form of computer attack.
  The stdlib `http.ServeMux` does optionally protect against this class of attack[3][4][5]
- In our implementation, we fail the requests with a http 400 and appropriate error message if the incoming host is not equal to(or a subdomain) of the registered domain.
- We also update the middleware `New` function so that it panics if the given domain is invalid.

1. Fixes: https://github.com/komuw/ong/issues/260
2. https://en.wikipedia.org/wiki/DNS_rebinding
3. https://github.com/golang/go/blob/go1.20.5/src/net/http/request.go#L232-L236
4. https://github.com/golang/go/blob/go1.20.5/src/net/http/server.go#L2467
5. https://github.com/golang/go/blob/go1.20.5/src/net/http/server.go#L2450-L2453