### PR TITLE
issues/280: add acme server that will handle requests from ACME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Most recent version is listed first.  
 
 
+# v0.0.53
+- Add acme server that will handle requests from ACME CA: https://github.com/komuw/ong/pull/281
+
 # v0.0.52
 - Bugfix; match number of log arguments: https://github.com/komuw/ong/pull/275
 - Add protection against DNS rebinding attacks: https://github.com/komuw/ong/pull/276

--- a/server/server.go
+++ b/server/server.go
@@ -253,7 +253,7 @@ func Run(h http.Handler, o Opts, l *slog.Logger) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	tlsConf, errTc := getTlsConfig(o)
+	tlsConf, errTc := getTlsConfig(ctx, h, o, l)
 	if errTc != nil {
 		return errTc
 	}

--- a/server/tls_conf.go
+++ b/server/tls_conf.go
@@ -9,10 +9,12 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/idna"
+	"github.com/komuw/ong/log"
 
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
+	"golang.org/x/exp/slog"
+	"golang.org/x/net/idna"
 )
 
 // Most of the code here is inspired(or taken from) by:
@@ -24,7 +26,9 @@ import (
 
 // getTlsConfig returns a proper tls configuration given the options passed in.
 // The tls config may either procure certifiates from ACME, from disk or be nil(for non-tls traffic)
-func getTlsConfig(o Opts) (*tls.Config, error) {
+//
+// h is the fallback is the http handler that will be delegated to for non ACME requests.
+func getTlsConfig(ctx context.Context, h http.Handler, o Opts, l *slog.Logger) (*tls.Config, error) {
 	if err := validateDomain(o.tls.domain); err != nil {
 		return nil, err
 	}
@@ -56,10 +60,59 @@ func getTlsConfig(o Opts) (*tls.Config, error) {
 				"http/1.1",
 				acme.ALPNProto, // enable tls-alpn ACME challenges
 			},
-			GetCertificate: func(info *tls.ClientHelloInfo) (certificate *tls.Certificate, e error) {
-				return m.GetCertificate(info)
+			GetCertificate: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+				// GetCertificate returns a Certificate based on the given ClientHelloInfo.
+				// it is called if `tls.Config.Certificates` is empty.
+				//
+				setFingerprint(info)
+
+				c, err := m.GetCertificate(info)
+				if err != nil {
+					// Ideally, we should not have to log here because the error bubbles up
+					// and should be logged up the stack.
+					// But for whatever reason, that doesn't happen.
+					// todo: we should investigate why.
+					l.Error("ong/server GetCertificate",
+						"acmeURL", o.tls.url,
+						"domain", o.tls.domain,
+						"tls.ClientHelloInfo.ServerName", info.ServerName,
+						"error", err,
+					)
+				}
+
+				return c, err
 			},
 		}
+
+		go func() {
+			// This server will handle requests to the ACME `/.well-known/acme-challenge/` URI.
+			// serve HTTP, which will redirect automatically to HTTPS
+			autocertHandler := m.HTTPHandler(h)
+			autocertServer := &http.Server{
+				Addr:     ":80",
+				Handler:  autocertHandler,
+				ErrorLog: slog.NewLogLogger(l.Handler(), slog.LevelDebug),
+			}
+
+			cfg := listenerConfig()
+			lstr, err := cfg.Listen(ctx, "tcp", autocertServer.Addr)
+			if err != nil {
+				l.Error("autocertServer, unable to create listener", "error", err)
+				return
+			}
+
+			slog.NewLogLogger(l.Handler(), log.LevelImmediate).
+				Printf("acme/autocert server listening at %s", autocertServer.Addr)
+
+			if err := autocertServer.Serve(lstr); err != nil {
+				l.Error("ong/server. acme/autocert unable to serve",
+					"func", "autocertServer.ListenAndServe",
+					"addr", autocertServer.Addr,
+					"error", err,
+				)
+			}
+		}()
+
 		return tlsConf, nil
 	}
 	if o.tls.certFile != "" {
@@ -79,11 +132,10 @@ func getTlsConfig(o Opts) (*tls.Config, error) {
 				"http/1.1",
 				acme.ALPNProto, // enable tls-alpn ACME challenges
 			},
-			GetCertificate: func(info *tls.ClientHelloInfo) (certificate *tls.Certificate, e error) {
+			GetCertificate: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
 				// GetCertificate returns a Certificate based on the given ClientHelloInfo.
 				// it is called if `tls.Config.Certificates` is empty.
 				//
-
 				setFingerprint(info)
 
 				return &c, nil

--- a/server/tls_conf.go
+++ b/server/tls_conf.go
@@ -87,7 +87,9 @@ func getTlsConfig(ctx context.Context, h http.Handler, o Opts, l *slog.Logger) (
 
 		go func() {
 			// This server will handle requests to the ACME `/.well-known/acme-challenge/` URI.
+			// Note that this `http-01` challenge does not allow wildcard certificates.
 			// see: https://letsencrypt.org/docs/challenge-types/
+			//      https://letsencrypt.org/docs/faq/#does-let-s-encrypt-issue-wildcard-certificates
 			autocertHandler := m.HTTPHandler(h)
 			autocertServer := &http.Server{
 				// serve HTTP, which will redirect automatically to HTTPS
@@ -111,11 +113,11 @@ func getTlsConfig(ctx context.Context, h http.Handler, o Opts, l *slog.Logger) (
 			slog.NewLogLogger(l.Handler(), log.LevelImmediate).
 				Printf("acme/autocert server listening at %s", autocertServer.Addr)
 
-			if err := autocertServer.Serve(lstr); err != nil {
+			if errAutocertSrv := autocertServer.Serve(lstr); errAutocertSrv != nil {
 				l.Error("ong/server. acme/autocert unable to serve",
 					"func", "autocertServer.ListenAndServe",
 					"addr", autocertServer.Addr,
-					"error", err,
+					"error", errAutocertSrv,
 				)
 			}
 		}()


### PR DESCRIPTION
- When a https request comes in, `acme/autocert` checks its cache for a TLS certicate.
  If one is not found, it asks ACME CA for it. The CA, sets up a challenge[2]. The CA
  expects the server to serve some challenge token at the `/.well-known/acme-challenge/` URI.
  Thus we need a server to serve the `autocert.Manager.HTTPHandler` which is http.Handler
  specifically for this job.
- Ideally, we should serve that handler in the normal ong http server[3].
  We should investigate how to do that in future.

1. Fixes: https://github.com/komuw/ong/issues/280
2. https://letsencrypt.org/docs/challenge-types
3. https://github.com/komuw/ong/blob/92fef920da4e8430921c64c37a9d67dcc7cee02c/server/server.go#L260