### PR TITLE
Make acme certificate manager a singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Most recent version is listed first.  
 
 
+# v0.0.57
+- Make acme certificate manager a singleton: https://github.com/komuw/ong/pull/293
+
 # v0.0.56
 - Set appropriate log level for http.Server.ErrorLog: https://github.com/komuw/ong/pull/288
 - Move acme handler to ong/middleware: https://github.com/komuw/ong/pull/290

--- a/internal/dmn/dmn.go
+++ b/internal/dmn/dmn.go
@@ -23,11 +23,15 @@ import (
 //
 
 var (
-	cmOnce sync.Once
+	// todo: I don't like that we have this globals here.
+	//       We should research on how to do better.
+	//
 	// Every time [CertManager] is called, we must return the same `cm`
 	// because `x/crypto/acme/autocert` mutates the certManager and hence we should
 	// get the same state across different invocations.
-	cm *autocert.Manager
+	//
+	cmOnce sync.Once         //nolint:gochecknoglobals
+	cm     *autocert.Manager //nolint:gochecknoglobals
 )
 
 // CertManager returns an ACME certificate manager for the given domain.

--- a/internal/dmn/dmn.go
+++ b/internal/dmn/dmn.go
@@ -22,26 +22,13 @@ import (
 //   (d) https://github.com/caddyserver/certmagic/blob/master/handshake.go whose license(Apache 2.0) can be found here:        https://github.com/caddyserver/certmagic/blob/v0.16.1/LICENSE.txt
 //
 
-var cm = &cManager{cm: map[string]*autocert.Manager{}}
-
-type cManager struct {
-	mu sync.Mutex // protects cm
-	cm map[string]*autocert.Manager
-}
-
-func (c *cManager) get(domain string) (*autocert.Manager, bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	r, ok := c.cm[domain]
-
-	return r, ok
-}
-
-func (c *cManager) set(domain string, m *autocert.Manager) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.cm[domain] = m
-}
+var (
+	cmOnce sync.Once
+	// Every time [CertManager] is called, we must return the same `cm`
+	// because `x/crypto/acme/autocert` mutates the certManager and hence we should
+	// get the same state across different invocations.
+	cm *autocert.Manager
+)
 
 // CertManager returns an ACME certificate manager for the given domain.
 // This should be called with a valid domain. Call [Validate] before calling this.
@@ -51,25 +38,24 @@ func CertManager(domain, acmeEmail, acmeDirectoryUrl string) *autocert.Manager {
 		return nil
 	}
 
-	if m, ok := cm.get(domain); ok {
-		return m
-	}
-
-	m := &autocert.Manager{
-		Client: &acme.Client{
-			DirectoryURL: acmeDirectoryUrl,
-			HTTPClient: &http.Client{
-				Timeout: 13 * time.Second,
+	// Ideally, we should have a certManager per unique domain.
+	// Currently, `ong` only handles one domain so this should be fine.
+	cmOnce.Do(func() {
+		cm = &autocert.Manager{
+			Client: &acme.Client{
+				DirectoryURL: acmeDirectoryUrl,
+				HTTPClient: &http.Client{
+					Timeout: 13 * time.Second,
+				},
 			},
-		},
-		Cache:      autocert.DirCache("ong-certifiate-dir"),
-		Prompt:     autocert.AcceptTOS,
-		Email:      acmeEmail,
-		HostPolicy: customHostWhitelist(domain),
-	}
-	cm.set(domain, m)
+			Cache:      autocert.DirCache("ong-certifiate-dir"),
+			Prompt:     autocert.AcceptTOS,
+			Email:      acmeEmail,
+			HostPolicy: customHostWhitelist(domain),
+		}
+	})
 
-	return m
+	return cm
 }
 
 // Validate checks domain for validity.

--- a/internal/dmn/dmn.go
+++ b/internal/dmn/dmn.go
@@ -33,6 +33,11 @@ var (
 // CertManager returns an ACME certificate manager for the given domain.
 // This should be called with a valid domain. Call [Validate] before calling this.
 // Callers should check if return value is nil.
+//
+// Support for acme certifiate manager needs to be added in three places:
+// (a) In http middlewares.
+// (b) In http server.
+// (c) In http multiplexer.
 func CertManager(domain, acmeEmail, acmeDirectoryUrl string) *autocert.Manager {
 	if domain == "" || acmeEmail == "" || acmeDirectoryUrl == "" {
 		return nil

--- a/internal/dmn/dmn.go
+++ b/internal/dmn/dmn.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"golang.org/x/crypto/acme"
@@ -22,37 +21,12 @@ import (
 //   (d) https://github.com/caddyserver/certmagic/blob/master/handshake.go whose license(Apache 2.0) can be found here:        https://github.com/caddyserver/certmagic/blob/v0.16.1/LICENSE.txt
 //
 
-var cm = &cManager{cm: map[string]*autocert.Manager{}}
-
-type cManager struct {
-	mu sync.Mutex // protects cm
-	cm map[string]*autocert.Manager
-}
-
-func (c *cManager) get(domain string) (*autocert.Manager, bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	r, ok := c.cm[domain]
-
-	return r, ok
-}
-
-func (c *cManager) set(domain string, m *autocert.Manager) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.cm[domain] = m
-}
-
 // CertManager returns an ACME certificate manager for the given domain.
 // This should be called with a valid domain. Call [Validate] before calling this.
 // Callers should check if return value is nil.
 func CertManager(domain, acmeEmail, acmeDirectoryUrl string) *autocert.Manager {
 	if domain == "" || acmeEmail == "" || acmeDirectoryUrl == "" {
 		return nil
-	}
-
-	if m, ok := cm.get(domain); ok {
-		return m
 	}
 
 	m := &autocert.Manager{
@@ -67,7 +41,6 @@ func CertManager(domain, acmeEmail, acmeDirectoryUrl string) *autocert.Manager {
 		Email:      acmeEmail,
 		HostPolicy: customHostWhitelist(domain),
 	}
-	cm.set(domain, m)
 
 	return m
 }

--- a/internal/dmn/dmn_test.go
+++ b/internal/dmn/dmn_test.go
@@ -241,12 +241,12 @@ func TestValidateDomain(t *testing.T) {
 func TestCertManager(t *testing.T) {
 	t.Parallel()
 
-	cm := CertManager("domain", "acmeEmail", "acmeDirectoryUrl")
-	attest.NotZero(t, cm)
+	acm := CertManager("domain", "acmeEmail", "acmeDirectoryUrl")
+	attest.NotZero(t, acm)
 
-	cm = CertManager("", "acmeEmail", "acmeDirectoryUrl")
-	attest.Zero(t, cm)
+	acm = CertManager("", "acmeEmail", "acmeDirectoryUrl")
+	attest.Zero(t, acm)
 
-	cm = CertManager("domain", "acmeEmail", "")
-	attest.Zero(t, cm)
+	acm = CertManager("domain", "acmeEmail", "")
+	attest.Zero(t, acm)
 }

--- a/middleware/acme.go
+++ b/middleware/acme.go
@@ -31,6 +31,10 @@ func acme(wrappedHandler http.Handler, domain, acmeEmail, acmeDirectoryUrl strin
 		acmeEnabled = true
 	}
 
+	// Support for acme certifiate manager needs to be added in three places:
+	// (a) In http middlewares.
+	// (b) In http server.
+	// (c) In http multiplexer.
 	return func(w http.ResponseWriter, r *http.Request) {
 		// This code is taken from; https://github.com/golang/crypto/blob/v0.10.0/acme/autocert/autocert.go#L398-L401
 		if acmeEnabled && strings.HasPrefix(r.URL.Path, acmeURI) {

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -48,7 +48,7 @@ const (
 // Use either [New] or [WithOpts] to get a valid Opts.
 type Opts struct {
 	domain           string
-	unCleanDomain    string // used by acme handler
+	acmeDomain       string // used by acme handler
 	acmeEmail        string
 	acmeDirectoryUrl string
 	httpsPort        uint16
@@ -58,6 +58,11 @@ type Opts struct {
 	secretKey        string
 	strategy         ClientIPstrategy
 	l                *slog.Logger
+}
+
+// Acme returns options used for procuring certificates from ACME certificate authorities.
+func (o Opts) Acme() (acmeDomain, acmeEmail, acmeDirectoryUrl string) {
+	return o.acmeDomain, o.acmeEmail, o.acmeDirectoryUrl
 }
 
 // New returns a new Opts.
@@ -100,7 +105,7 @@ func New(
 		panic(err)
 	}
 
-	unCleanDomain := domain
+	acmeDomain := domain
 	if strings.Contains(domain, "*") {
 		// remove the `*` and `.`
 		domain = domain[2:]
@@ -108,7 +113,7 @@ func New(
 
 	return Opts{
 		domain:           domain,
-		unCleanDomain:    unCleanDomain,
+		acmeDomain:       acmeDomain,
 		acmeEmail:        acmeEmail,
 		acmeDirectoryUrl: acmeDirectoryUrl,
 		httpsPort:        httpsPort,
@@ -178,7 +183,7 @@ func allDefaultMiddlewares(
 	o Opts,
 ) http.HandlerFunc {
 	domain := o.domain
-	unCleanDomain := o.unCleanDomain
+	acmeDomain := o.acmeDomain
 	acmeEmail := o.acmeEmail
 	acmeDirectoryUrl := o.acmeDirectoryUrl
 	httpsPort := o.httpsPort
@@ -262,7 +267,7 @@ func allDefaultMiddlewares(
 										httpsPort,
 										domain,
 									),
-									unCleanDomain,
+									acmeDomain,
 									acmeEmail,
 									acmeDirectoryUrl,
 								),

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -111,7 +111,7 @@ func New(l *slog.Logger, opt middleware.Opts, notFoundHandler http.Handler, rout
 
 			m.addPattern(
 				MethodAll,
-				"/.well-known/acme-challenge/", // TODO: make it a constant
+				"/.well-known/acme-challenge/"+":token", // TODO: make it a constant
 				acmeHandler,
 				middleware.All(acmeHandler, opt),
 			)

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/komuw/ong/internal/dmn"
 	"github.com/komuw/ong/middleware"
 
 	"golang.org/x/exp/slog"
@@ -101,6 +102,20 @@ func New(l *slog.Logger, opt middleware.Opts, notFoundHandler http.Handler, rout
 			rt.originalHandler,
 			mid(rt.originalHandler, opt),
 		)
+	}
+
+	{
+		cm := dmn.CertManager(opt.Acme())
+		if cm != nil {
+			acmeHandler := cm.HTTPHandler(nil) // TODO: should we pass in a fallback handler here??
+
+			m.addPattern(
+				MethodAll,
+				"/.well-known/acme-challenge/", // TODO: make it a constant
+				acmeHandler,
+				middleware.All(acmeHandler, opt),
+			)
+		}
 	}
 
 	return m

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -105,6 +105,10 @@ func New(l *slog.Logger, opt middleware.Opts, notFoundHandler http.Handler, rout
 	}
 
 	{
+		// Support for acme certifiate manager needs to be added in three places:
+		// (a) In http middlewares.
+		// (b) In http server.
+		// (c) In http multiplexer.
 		cm := dmn.CertManager(opt.Acme())
 		if cm != nil {
 			const acmeURI = "/.well-known/acme-challenge/:token"

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -107,11 +107,12 @@ func New(l *slog.Logger, opt middleware.Opts, notFoundHandler http.Handler, rout
 	{
 		cm := dmn.CertManager(opt.Acme())
 		if cm != nil {
-			acmeHandler := cm.HTTPHandler(nil) // TODO: should we pass in a fallback handler here??
+			const acmeURI = "/.well-known/acme-challenge/:token"
+			acmeHandler := cm.HTTPHandler(m)
 
 			m.addPattern(
 				MethodAll,
-				"/.well-known/acme-challenge/"+":token", // TODO: make it a constant
+				acmeURI,
 				acmeHandler,
 				middleware.All(acmeHandler, opt),
 			)

--- a/mux/route.go
+++ b/mux/route.go
@@ -130,6 +130,8 @@ func (r *router) serveHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
+	fmt.Println("\n\t router.serveHTTP", "req.URL.Path", req.URL.Path, "routes", r.routes, "\n.")
+
 	r.notFoundHandler.ServeHTTP(w, req)
 }
 

--- a/mux/route.go
+++ b/mux/route.go
@@ -130,8 +130,6 @@ func (r *router) serveHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	fmt.Println("\n\t router.serveHTTP", "req.URL.Path", req.URL.Path, "\n.")
-
 	r.notFoundHandler.ServeHTTP(w, req)
 }
 

--- a/mux/route.go
+++ b/mux/route.go
@@ -130,7 +130,7 @@ func (r *router) serveHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	fmt.Println("\n\t router.serveHTTP", "req.URL.Path", req.URL.Path, "routes", r.routes, "\n.")
+	fmt.Println("\n\t router.serveHTTP", "req.URL.Path", req.URL.Path, "\n.")
 
 	r.notFoundHandler.ServeHTTP(w, req)
 }

--- a/server/tls_conf.go
+++ b/server/tls_conf.go
@@ -33,6 +33,10 @@ func getTlsConfig(o Opts) (c *tls.Config, e error) {
 			return nil, errors.New("ong/server: acmeDirectoryUrl cannot be empty if acmeEmail is also specified")
 		}
 
+		// Support for acme certifiate manager needs to be added in three places:
+		// (a) In http middlewares.
+		// (b) In http server.
+		// (c) In http multiplexer.
 		cm := dmn.CertManager(o.tls.domain, o.tls.acmeEmail, o.tls.acmeDirectoryUrl)
 		if cm == nil {
 			return nil, errors.New("ong/server: unable to setup acme manager")


### PR DESCRIPTION
- Support for acme certifiate manager needs to be added in three places, in:
    (a) http middlewares.
    (b) http server.
    (c) http multiplexer.
  When procuring certificates(and running in general), `x/crypto/acme` will mutate the certificateManager to add state.
  Thus the three places(above) that require the certificate manager ought to share the same instance.
  Hence this change. 