### PR TITLE
Work around bug in checklocks static analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Most recent version is listed first.
 
 # v0.0.57
 - Add own ACME client implementation: https://github.com/komuw/ong/pull/294
+- Work around bug in checklocks static analyzer: https://github.com/komuw/ong/pull/298
 
 # v0.0.56
 - Set appropriate log level for http.Server.ErrorLog: https://github.com/komuw/ong/pull/288

--- a/internal/acme/acme.go
+++ b/internal/acme/acme.go
@@ -306,7 +306,7 @@ func (m *manager) getCert(domain string) (cert *tls.Certificate, _ error) {
 		cert = c
 	}
 
-	{ // 4. Add to cache and disk.
+	{ // 4. Add to cache and disk. This should be done ONLY if cert came from ACME.
 		// This block should ideally have been in a defer;
 		// However; the `checklocks` static analyzer complains.
 		// see: https://github.com/komuw/ong/blob/3153948e1a6ac10c7744ed46356cd1491f1dda50/internal/acme/acme.go#L284-L295

--- a/internal/acme/acme.go
+++ b/internal/acme/acme.go
@@ -268,7 +268,7 @@ func initManager(domain, email, acmeDirectoryUrl string, l *slog.Logger, testDis
 
 // getCert fetches a tls certificate for domain.
 func (m *manager) getCert(domain string) (*tls.Certificate, error) {
-	cert, certFromAcme, err := m._getCert(domain)
+	cert, certFromAcme, err := m.innerGetCert(domain)
 
 	defer func() {
 		m.mu.Lock()
@@ -288,10 +288,10 @@ func (m *manager) getCert(domain string) (*tls.Certificate, error) {
 	return cert, err
 }
 
-// _getCert is a helper func for getCert. It should ONLY be called by getCert.
+// innerGetCert is a helper func for getCert. It should ONLY be called by getCert.
 // The two funcs should ideally be folded into one, however; the `checklocks` static analyzer complains.
 // See: https://github.com/komuw/ong/issues/297
-func (m *manager) _getCert(domain string) (_ *tls.Certificate, certFromAcme bool, _ error) {
+func (m *manager) innerGetCert(domain string) (_ *tls.Certificate, certFromAcme bool, _ error) {
 	/*
 		1. Get cert from memory/cache.
 		2. Else get from disk(also save to memory).

--- a/internal/acme/acme.go
+++ b/internal/acme/acme.go
@@ -175,7 +175,7 @@ func Handler(wrappedHandler http.Handler) http.HandlerFunc {
 				return
 			}
 
-			_, _ = fmt.Fprint(w, string(tok))
+			_, _ = w.Write(tok)
 			w.WriteHeader(http.StatusOK)
 
 			return

--- a/internal/acme/client.go
+++ b/internal/acme/client.go
@@ -112,7 +112,7 @@ func getDirectory(directoryURL string, l *slog.Logger) (directory, error) {
 	if errA != nil {
 		return d, errA
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
 		ae := &acmeError{}
@@ -141,7 +141,7 @@ func getNonce(newNonceURL string, l *slog.Logger) (string, error) {
 	if errA != nil {
 		return "", errA
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
 		ae := &acmeError{}
@@ -205,7 +205,7 @@ func getAccount(newAccountURL, newNonceURL, email string, accountPrivKey *ecdsa.
 	if errC != nil {
 		return actResponse, errC
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode == http.StatusCreated || res.StatusCode == http.StatusOK {
 		if errD := json.NewDecoder(res.Body).Decode(&actResponse); errD != nil {
@@ -288,7 +288,7 @@ func submitOrder(newOrderURL, newNonceURL, kid string, domains []string, account
 	if errC != nil {
 		return orderResponse, errC
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode == http.StatusCreated {
 		if errD := json.NewDecoder(res.Body).Decode(&orderResponse); errD != nil {
@@ -354,7 +354,7 @@ func fetchChallenges(authorizationURLS []string, newNonceURL, kid string, accoun
 	if errB != nil {
 		return authorizationResponse, errB
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode == http.StatusOK {
 		if errC := json.NewDecoder(res.Body).Decode(&authorizationResponse); errC != nil {
@@ -447,7 +447,7 @@ func checkChallengeStatus(
 			checkError = errB
 			continue
 		}
-		defer res.Body.Close()
+		defer func() { _ = res.Body.Close() }()
 		dur = retryAfter(res.Header.Get("Retry-After"), dur) + (2 * time.Second)
 
 		if res.StatusCode != http.StatusOK {
@@ -520,7 +520,7 @@ func respondToChallenge(ch challenge, newNonceURL, kid string, accountPrivKey *e
 	if errD != nil {
 		return challengeResponse, errD
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode == http.StatusOK {
 		if errE := json.NewDecoder(res.Body).Decode(&challengeResponse); errE != nil {
@@ -617,7 +617,7 @@ func checkOrderStatus(
 			checkError = errB
 			continue
 		}
-		defer res.Body.Close()
+		defer func() { _ = res.Body.Close() }()
 		dur = retryAfter(res.Header.Get("Retry-After"), dur) + (2 * time.Second)
 
 		if res.StatusCode != http.StatusOK {
@@ -721,7 +721,7 @@ func sendCSR(domain string, o order, newNonceURL, kid string, accountPrivKey, ce
 	if errE != nil {
 		return o, errE
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode == http.StatusOK {
 		/*
@@ -802,7 +802,7 @@ func downloadCertificate(o order, newNonceURL, kid string, accountPrivKey *ecdsa
 	if errC != nil {
 		return nil, errC
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode == http.StatusOK {
 		c, errD := io.ReadAll(res.Body)

--- a/internal/acme/helpers.go
+++ b/internal/acme/helpers.go
@@ -209,7 +209,7 @@ func certFromDisk(certPath string) (*tls.Certificate, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	return certFromReader(f)
 }

--- a/internal/acme/http_client.go
+++ b/internal/acme/http_client.go
@@ -171,7 +171,7 @@ func prepBody(url, newNonceURL, kid string, dataPayload []byte, accountPrivKey *
 	}
 
 	hash := sha.New()
-	hash.Write([]byte(protPayloadStr + "." + dataPayloadStr))
+	_, _ = io.WriteString(hash, protPayloadStr+"."+dataPayloadStr)
 	sig, err := jwsSign(accountPrivKey, sha, hash.Sum(nil))
 	if err != nil {
 		return nil, err
@@ -214,5 +214,5 @@ func dumpDebugW(w io.Writer, req *http.Request, res *http.Response) {
 	}
 	s = s + "\n===========================DUMPING RESPONSE===========================\n\n"
 
-	_, _ = w.Write([]byte(s))
+	_, _ = io.WriteString(w, s)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -30,7 +30,7 @@ func getSecretKey() string {
 // getPort returns a random port.
 // The idea is that different tests should run on different independent ports to avoid collisions.
 func getPort() uint16 {
-	r := rand.Intn(100) + 1
+	r := rand.Intn(10_000) + 1
 	p := math.MaxUint16 - uint16(r)
 	return p
 }


### PR DESCRIPTION
- The issue is that the checklocks analyzer cannot tell that the following code is safe;
```go
package main

import "sync"

var mu sync.Mutex

func cool() string {
	mu.Lock()
	defer mu.Unlock()

	defer func() {
		_ = 90
	}()
	return "jj"
}

func main() {
	cool()
}
```
  See[2]. So we have to add an indirection to make that static analyzer happy.

1. Fixes: https://github.com/komuw/ong/issues/297
2. https://github.com/google/gvisor/tree/release-20230627.0/tools/checklocks#anonymous-functions-and-closures