### PR TITLE
issues/48: Fix superfluous response.WriteHeader call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Most recent version is listed first.
 - Make tests fast by pinging port: https://github.com/komuw/ong/pull/299
 - Synchronize automax tests: https://github.com/komuw/ong/pull/300
 - Improve rate limit tests: https://github.com/komuw/ong/pull/301
+- Fix superfluous response.WriteHeader call: https://github.com/komuw/ong/pull/302
 
 # v0.0.56
 - Set appropriate log level for http.Server.ErrorLog: https://github.com/komuw/ong/pull/288

--- a/internal/acme/client_test.go
+++ b/internal/acme/client_test.go
@@ -42,6 +42,9 @@ func someAcmeServerHandler(t *testing.T, domain string) http.HandlerFunc {
 			// Changing the header map after a call to WriteHeader (or Write) has no effect.
 			// So, `WriteHeader` should be called last.
 			// Otherwise, for the others; `WriteHeader` should be called first.
+			//
+			// If WriteHeader is not called explicitly, the first call to Write
+			// will trigger an implicit WriteHeader(http.StatusOK).
 			w.Header().Set("Replay-Nonce", "some-random-unique-nonce")
 			w.WriteHeader(http.StatusOK)
 			return


### PR DESCRIPTION
- When `http.ResponseWriter.WriteHeader()` is called more than once, it always produces the error;
  `http: superfluous response.WriteHeader call from github.com/komuw/ong/middleware.(*logRW).WriteHeader (log.go:121)`
  And the stack trace always points to the ong log middleware. But that does not mean that ong has any issues.
  That error is always produced irrespective of if `ong` is used. It's how `net/http` works[2]
- Also note that; if `http.ResponseWriter.WriteHeader` is not called explicitly, the first call to Write
  will trigger[3] an implicit WriteHeader(http.StatusOK).
- So this PR does not fix the issue(since it is an actual feature of `net/http`), rather it clarifies that understanding.

1. Fixes: https://github.com/komuw/ong/issues/48
2. https://github.com/komuw/ong/issues/48#issuecomment-1260654535
3. https://github.com/golang/go/blob/go1.20.5/src/net/http/server.go#L141-L159