### PR TITLE
issues/296: Fix bug where acme certificates were not cached in memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Most recent version is listed first.  
 
 
+# v0.0.59
+- Fix bug where acme certificates were not cached in memory: https://github.com/komuw/ong/pull/304
+
 # v0.0.58
 - Tighten check cert validity script: https://github.com/komuw/ong/pull/303
 

--- a/internal/acme/acme.go
+++ b/internal/acme/acme.go
@@ -76,6 +76,7 @@ func Validate(domain string) error {
 
 // GetCertificate returns a function that implements [tls.Config.GetCertificate].
 // It provides a TLS certificate for hello.ServerName host.
+// It should be called once and then returned function can be called per request.
 //
 // GetCertificate panics on error, however the returned function handles errors normally.
 func GetCertificate(domain, email, acmeDirectoryUrl string, l *slog.Logger) func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {

--- a/internal/acme/acme.go
+++ b/internal/acme/acme.go
@@ -76,7 +76,7 @@ func Validate(domain string) error {
 
 // GetCertificate returns a function that implements [tls.Config.GetCertificate].
 // It provides a TLS certificate for hello.ServerName host.
-// It should be called once and then returned function can be called per request.
+// It should be called once and then the returned function can be called per request.
 //
 // GetCertificate panics on error, however the returned function handles errors normally.
 func GetCertificate(domain, email, acmeDirectoryUrl string, l *slog.Logger) func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {


### PR DESCRIPTION
- Before(due to a feature misuse bug), certificates would be fetched from disk for each request.

- Fixes: https://github.com/komuw/ong/issues/296