### PR TITLE
ong/id: Do not use crypto/rand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 1
     strategy:
       matrix:
-        go-version: ['>=1.20.5']
+        go-version: ['>=1.20.6']
         platform: [ubuntu-22.04]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -68,7 +68,7 @@ jobs:
     timeout-minutes: 7
     strategy:
       matrix:
-        go-version: ['>=1.20.5']
+        go-version: ['>=1.20.6']
         platform: [ubuntu-22.04]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -102,7 +102,7 @@ jobs:
     timeout-minutes: 6
     strategy:
       matrix:
-        go-version: ['>=1.20.5']
+        go-version: ['>=1.20.6']
         platform: [ubuntu-22.04]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -206,7 +206,7 @@ jobs:
     timeout-minutes: 3
     strategy:
       matrix:
-        go-version: ['>=1.20.5']
+        go-version: ['>=1.20.6']
         platform: [ubuntu-22.04]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -250,7 +250,7 @@ jobs:
   #   timeout-minutes: 2
   #   strategy:
   #     matrix:
-  #       go-version: ['>=1.20.5']
+  #       go-version: ['>=1.20.6']
   #       platform: [ubuntu-22.04]
   #   runs-on: ${{ matrix.platform }}
   #   steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Most recent version is listed first.  
 
 
+# v0.0.65
+- ong/id: Do not use crypto/rand: https://github.com/komuw/ong/pull/322
+
 # v0.0.64
 - ong/acme: Limit size of certificate allowed for download: https://github.com/komuw/ong/pull/321
 

--- a/id/id.go
+++ b/id/id.go
@@ -1,9 +1,7 @@
-// Package id generates unique random strings.
-// It however should not be used for cryptography purposes.
+// Package id generates unique random identifiers.
 package id
 
 import (
-	cryptoRand "crypto/rand"
 	"encoding/base64"
 	mathRand "math/rand"
 )
@@ -24,14 +22,17 @@ func encoding() *base64.Encoding {
 var enc = encoding() //nolint:gochecknoglobals
 
 // New returns a new random string.
+// It uses a character set that is legible.
+// It should not be used for cryptography purposes.
 func New() string {
 	return Random(16)
 }
 
 // Random generates a random string of size n.
-//
+// It uses a character set that is legible.
 // If n < 1 or significantly large, it is set to reasonable bounds.
-// It uses `crypto/rand` but falls back to `math/rand` on error.
+//
+// It should not be used for cryptography purposes.
 func Random(n int) string {
 	if n < 1 {
 		n = 1
@@ -44,15 +45,11 @@ func Random(n int) string {
 
 	// This formula is from [base64.Encoding.EncodedLen]
 	byteSize := ((((n * 6) - 5) / 8) + 1)
-
 	b := make([]byte, byteSize)
-	if _, err := cryptoRand.Read(b); err != nil {
-		b = make([]byte, byteSize)
-		//lint:ignore SA1019 `mathRand.Read` is deprecated.
-		// However, for our case here is okay since the func id.Random is not used for cryptography.
-		// Also we like the property of `mathRand.Read` always returning a nil error.
-		_, _ = mathRand.Read(b) // nolint:staticcheck
-	}
+	//lint:ignore SA1019 `mathRand.Read` is deprecated.
+	// However, for our case here is okay since the func id.Random is not used for cryptography.
+	// Also we like the property of `mathRand.Read` always returning a nil error.
+	_, _ = mathRand.Read(b) // nolint:staticcheck
 
 	return enc.EncodeToString(b)[:n]
 }

--- a/id/uuid.go
+++ b/id/uuid.go
@@ -26,6 +26,7 @@ const (
 // [unique]: https://en.wikipedia.org/wiki/Universally_unique_identifier
 type UUID [16]byte
 
+// String implements [fmt.Stringer] for uuid.
 func (u UUID) String() string {
 	return fmt.Sprintf(
 		"%x-%x-%x-%x-%x",


### PR DESCRIPTION
- It was confusing whether `id.New()` could be used for cryptography purposes.