### PR TITLE
Update security headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Most recent version is listed first.  
 
 
+# v0.0.67
+- ong/middleware: Update security headers: https://github.com/komuw/ong/pull/330
+
 # v0.0.66
 - ong/acme: Bugfix, fetch certficate for subdomain beginning with number: https://github.com/komuw/ong/pull/328
 

--- a/middleware/security.go
+++ b/middleware/security.go
@@ -62,6 +62,7 @@ func securityHeaders(wrappedHandler http.Handler, domain string) http.HandlerFun
 			// - https://stackoverflow.com/a/66955464/2768067
 			// - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
 			// - https://web.dev/security-headers/#tt
+			// - https://securityheaders.com/
 			//
 			// content is only permitted from:
 			// - the document's origin(and subdomains)
@@ -130,14 +131,9 @@ func getCsp(domain, nonce string) string {
 	// - media is allowed from domain(and its subdomains)
 	// - executable scripts is only allowed from self(& subdomains).
 	// - DOM xss(eg setting innerHtml) is blocked by require-trusted-types.
-	return fmt.Sprintf(`
-default-src 'self' %s *.%s;
-img-src *;
-media-src %s *.%s;
-object-src 'none';
-base-uri 'none';
-require-trusted-types-for 'script';
-script-src 'self' %s *.%s 'unsafe-inline' 'nonce-%s';`,
+	return fmt.Sprintf(
+		// It does not work if they are not all in same line.
+		"default-src 'self' %s *.%s; img-src *; media-src %s *.%s; object-src 'none'; base-uri 'none'; require-trusted-types-for 'script'; script-src 'self' %s *.%s 'unsafe-inline' 'nonce-%s';",
 		domain, domain,
 		domain, domain,
 		domain, domain, nonce,

--- a/middleware/security.go
+++ b/middleware/security.go
@@ -103,7 +103,7 @@ func securityHeaders(wrappedHandler http.Handler, domain string) http.HandlerFun
 				stsHeader,
 				// - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
 				// A max-age(in seconds) of 2yrs is recommended
-				getSts(15*24*time.Hour), // 15 days
+				getSts(60*24*time.Hour), // 60 days
 			)
 		}
 

--- a/middleware/security.go
+++ b/middleware/security.go
@@ -137,7 +137,11 @@ media-src %s *.%s;
 object-src 'none';
 base-uri 'none';
 require-trusted-types-for 'script';
-script-src 'self' %s *.%s 'unsafe-inline' 'nonce-%s';`, domain, domain, domain, domain, domain, domain, nonce)
+script-src 'self' %s *.%s 'unsafe-inline' 'nonce-%s';`,
+		domain, domain,
+		domain, domain,
+		domain, domain, nonce,
+	)
 }
 
 func getSts(age time.Duration) string {

--- a/middleware/security_test.go
+++ b/middleware/security_test.go
@@ -70,7 +70,7 @@ func TestSecurity(t *testing.T) {
 			corpHeader:              "same-site",
 			coopHeader:              "same-origin",
 			referrerHeader:          "strict-origin-when-cross-origin",
-			stsHeader:               getSts(15 * 24 * time.Hour),
+			stsHeader:               getSts(60 * 24 * time.Hour),
 		}
 
 		for k, v := range expect {


### PR DESCRIPTION
- The recomended minimum value strict-transport-security is 30days
- Content-Security-Policy should be in one line else it does not show up