### PR TITLE
issues/339: Send Allow http header when we respond with http 405 status code.

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -21,8 +21,8 @@
  },
  {
   "Description": "Generic API Key",
-  "StartLine": 26,
-  "EndLine": 26,
+  "StartLine": 27,
+  "EndLine": 27,
   "StartColumn": 5,
   "EndColumn": 48,
   "Match": "key:  \"663acecd-af38-4e02-9529-1498bd7bd96e\"",
@@ -37,6 +37,6 @@
   "Message": "",
   "Tags": [],
   "RuleID": "generic-api-key",
-  "Fingerprint": "internal/key/key_test.go:generic-api-key:26"
+  "Fingerprint": "internal/key/key_test.go:generic-api-key:27"
  }
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Most recent version is listed first.
 
 # v0.0.70
 - ong/middleware: Fix DNS rebinding via http: https://github.com/komuw/ong/compare/issues/337
+- And test util: https://github.com/komuw/ong/pull/344
 
 # v0.0.70
 - ong/server: Dynamically assign port for pprof: https://github.com/komuw/ong/pull/343

--- a/cookie/cookie_test.go
+++ b/cookie/cookie_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/komuw/ong/internal/tst"
 	"go.akshayshah.org/attest"
 	"go.uber.org/goleak"
 )
@@ -123,7 +124,7 @@ func TestCookies(t *testing.T) {
 		value := "hello world are you okay"
 		domain := "localhost"
 		mAge := 23 * time.Hour
-		secretKey := "super-h@rd-Pa$1word"
+		secretKey := tst.SecretKey()
 		handler := setEncryptedHandler(name, value, domain, mAge, secretKey)
 
 		rec := httptest.NewRecorder()
@@ -159,7 +160,7 @@ func TestCookies(t *testing.T) {
 		value := "hello world are you okay"
 		domain := "localhost"
 		mAge := -23 * time.Hour
-		secretKey := "super-h@rd-Pa$1word"
+		secretKey := tst.SecretKey()
 		handler := setEncryptedHandler(name, value, domain, mAge, secretKey)
 
 		rec := httptest.NewRecorder()
@@ -238,6 +239,6 @@ func BenchmarkSetEncrypted(b *testing.B) {
 }
 
 func testSetEncrypted(req *http.Request, res http.ResponseWriter) int {
-	SetEncrypted(req, res, "name", "value", "example.com", 2*time.Hour, "super-h@rd-Pa$1word")
+	SetEncrypted(req, res, "name", "value", "example.com", 2*time.Hour, tst.SecretKey())
 	return 3
 }

--- a/cry/enc_test.go
+++ b/cry/enc_test.go
@@ -4,14 +4,11 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/komuw/ong/internal/tst"
 	"go.akshayshah.org/attest"
 	"go.uber.org/goleak"
 	"golang.org/x/exp/slices"
 )
-
-func getSecretKey() string {
-	return "super-h@rd-Pa$1word"
-}
 
 func TestMain(m *testing.M) {
 	// call flag.Parse() here if TestMain uses flags
@@ -25,7 +22,7 @@ func TestEnc(t *testing.T) {
 		t.Parallel()
 
 		// okay key
-		key := getSecretKey()
+		key := tst.SecretKey()
 		_ = New(key)
 
 		// short key
@@ -38,7 +35,7 @@ func TestEnc(t *testing.T) {
 		t.Parallel()
 
 		msgToEncrypt := "hello world!"
-		key := getSecretKey()
+		key := tst.SecretKey()
 		enc := New(key)
 
 		encryptedMsg := enc.Encrypt(msgToEncrypt)
@@ -53,7 +50,7 @@ func TestEnc(t *testing.T) {
 		t.Parallel()
 
 		msgToEncrypt := "hello world!"
-		key := getSecretKey()
+		key := tst.SecretKey()
 		enc := New(key)
 
 		token := enc.EncryptEncode(msgToEncrypt)
@@ -70,7 +67,7 @@ func TestEnc(t *testing.T) {
 		// against breachattack.
 
 		msgToEncrypt := "hello world!"
-		key := getSecretKey()
+		key := tst.SecretKey()
 		enc := New(key)
 
 		encryptedMsg := enc.Encrypt(msgToEncrypt)
@@ -100,7 +97,7 @@ func TestEnc(t *testing.T) {
 		// even if the server was restarted; so long as the same key is re-used.
 
 		msgToEncrypt := "hello world!"
-		key := getSecretKey()
+		key := tst.SecretKey()
 
 		enc1 := New(key)
 		encryptedMsg := enc1.Encrypt(msgToEncrypt)
@@ -117,7 +114,7 @@ func TestEnc(t *testing.T) {
 		msgToEncrypt := "hello world!"
 
 		run := func() {
-			key := getSecretKey()
+			key := tst.SecretKey()
 			enc := New(key)
 
 			encryptedMsg := enc.Encrypt(msgToEncrypt)
@@ -143,7 +140,7 @@ var result []byte //nolint:gochecknoglobals
 func BenchmarkEnc(b *testing.B) {
 	var r []byte
 	msgToEncrypt := "hello world!"
-	key := getSecretKey()
+	key := tst.SecretKey()
 	enc := New(key)
 
 	b.ReportAllocs()

--- a/internal/README.md
+++ b/internal/README.md
@@ -7,3 +7,4 @@ The packages in this directory:
 3. The `github.com/komuw/ong/internal/finger` package is need by both `github.com/komuw/ong/middleware` & `github.com/komuw/ong/server`
 4. The `github.com/komuw/ong/internal/acme` package is need by both `github.com/komuw/ong/middleware` & `github.com/komuw/ong/server`
 5. The `github.com/komuw/ong/internal/key` package is need by both `github.com/komuw/ong/middleware` & `github.com/komuw/ong/cry`
+6. The `github.com/komuw/ong/internal/t` package is need by both `github.com/komuw/ong/middleware`, `github.com/komuw/ong/mux`, `github.com/komuw/ong/server`, etc

--- a/internal/key/key_test.go
+++ b/internal/key/key_test.go
@@ -3,6 +3,7 @@ package key
 import (
 	"testing"
 
+	"github.com/komuw/ong/internal/tst"
 	"go.akshayshah.org/attest"
 )
 
@@ -16,7 +17,7 @@ func TestCheckSecretKey(t *testing.T) {
 	}{
 		{
 			name: "good key",
-			key:  "super-h@rd-Pa$1word",
+			key:  tst.SecretKey(),
 			check: func(err error) {
 				attest.Ok(t, err)
 			},

--- a/internal/tst/tst.go
+++ b/internal/tst/tst.go
@@ -13,13 +13,14 @@ import (
 	"go.akshayshah.org/attest"
 )
 
-// CustomServer starts a server at a predetermined port.
+// TlsServer starts a test TLS server at a predetermined port and returns it.
 // It's upto callers to close the server.
-func CustomServer(t attest.TB, h http.Handler, domain string, httpsPort uint16) *httptest.Server {
+func TlsServer(t attest.TB, h http.Handler, domain string, httpsPort uint16) *httptest.Server {
 	t.Helper()
 
 	ts := httptest.NewUnstartedServer(h)
-	ts.Listener.Close()
+	err := ts.Listener.Close()
+	attest.Ok(t, err)
 
 	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", domain, httpsPort))
 	attest.Ok(t, err)

--- a/internal/tst/tst.go
+++ b/internal/tst/tst.go
@@ -22,7 +22,7 @@ func TlsServer(t attest.TB, h http.Handler, domain string, httpsPort uint16) *ht
 	err := ts.Listener.Close()
 	attest.Ok(t, err)
 
-	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", domain, httpsPort))
+	l, err := net.Listen("tcp", net.JoinHostPort(domain, fmt.Sprintf("%d", httpsPort)))
 	attest.Ok(t, err)
 
 	ts.Listener = l

--- a/internal/tst/tst.go
+++ b/internal/tst/tst.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"time"
 
 	"go.akshayshah.org/attest"
 )
@@ -35,4 +36,35 @@ func GetPort() uint16 {
 	r := rand.Intn(10_000) + 1
 	p := math.MaxUint16 - uint16(r)
 	return p
+}
+
+// SecretKey returns a secret key that is valid and can be used in tests.
+func SecretKey() string {
+	return "super-h@rd-Pa$1word"
+}
+
+// Ping waits for port to be open, it fails after a number of given seconds.
+func Ping(t attest.TB, port uint16) {
+	t.Helper()
+
+	var err error
+	count := 0
+	maxCount := 12
+	defer func() {
+		attest.Ok(t, err)
+	}()
+
+	for {
+		count = count + 1
+		time.Sleep(1 * time.Second)
+		_, err = net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), 1*time.Second)
+		if err == nil {
+			break
+		}
+
+		if count > maxCount {
+			err = fmt.Errorf("ping max count(%d) reached: %w", maxCount, err)
+			break
+		}
+	}
 }

--- a/internal/tst/tst.go
+++ b/internal/tst/tst.go
@@ -1,0 +1,38 @@
+// Package tst implements some common test functionality needed across ong.
+package tst
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/http/httptest"
+
+	"go.akshayshah.org/attest"
+)
+
+// CustomServer starts a server at a predetermined port.
+// It's upto callers to close the server.
+func CustomServer(t attest.TB, h http.Handler, domain string, httpsPort uint16) *httptest.Server {
+	t.Helper()
+
+	ts := httptest.NewUnstartedServer(h)
+	ts.Listener.Close()
+
+	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", domain, httpsPort))
+	attest.Ok(t, err)
+
+	ts.Listener = l
+	ts.StartTLS()
+
+	return ts
+}
+
+// GetPort returns a random port.
+// The idea is that different tests should run on different independent ports to avoid collisions.
+func GetPort() uint16 {
+	r := rand.Intn(10_000) + 1
+	p := math.MaxUint16 - uint16(r)
+	return p
+}

--- a/middleware/csrf_test.go
+++ b/middleware/csrf_test.go
@@ -13,14 +13,10 @@ import (
 
 	"github.com/komuw/ong/cry"
 	"github.com/komuw/ong/id"
+	"github.com/komuw/ong/internal/tst"
 
 	"go.akshayshah.org/attest"
 )
-
-func getSecretKey() string {
-	key := "super-h@rd-Pa$1word"
-	return key
-}
 
 func TestGetToken(t *testing.T) {
 	t.Parallel()
@@ -130,7 +126,7 @@ func TestCsrf(t *testing.T) {
 
 		msg := "hello"
 		domain := "example.com"
-		wrappedHandler := csrf(someCsrfHandler(msg), getSecretKey(), domain)
+		wrappedHandler := csrf(someCsrfHandler(msg), tst.SecretKey(), domain)
 
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/someUri", nil)
@@ -151,7 +147,7 @@ func TestCsrf(t *testing.T) {
 
 		msg := "hello"
 		domain := "example.com"
-		wrappedHandler := csrf(someCsrfHandler(msg), getSecretKey(), domain)
+		wrappedHandler := csrf(someCsrfHandler(msg), tst.SecretKey(), domain)
 
 		reqCsrfTok := id.Random(csrfBytesTokenLength)
 		rec := httptest.NewRecorder()
@@ -182,7 +178,7 @@ func TestCsrf(t *testing.T) {
 
 		msg := "hello"
 		domain := "example.com"
-		wrappedHandler := csrf(someCsrfHandler(msg), getSecretKey(), domain)
+		wrappedHandler := csrf(someCsrfHandler(msg), tst.SecretKey(), domain)
 
 		reqCsrfTok := id.Random(csrfBytesTokenLength)
 		rec := httptest.NewRecorder()
@@ -206,7 +202,7 @@ func TestCsrf(t *testing.T) {
 
 		msg := "hello"
 		domain := "example.com"
-		wrappedHandler := csrf(someCsrfHandler(msg), getSecretKey(), domain)
+		wrappedHandler := csrf(someCsrfHandler(msg), tst.SecretKey(), domain)
 
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/someUri", nil)
@@ -228,7 +224,7 @@ func TestCsrf(t *testing.T) {
 
 		msg := "hello"
 		domain := "example.com"
-		wrappedHandler := csrf(someCsrfHandler(msg), getSecretKey(), domain)
+		wrappedHandler := csrf(someCsrfHandler(msg), tst.SecretKey(), domain)
 
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/someUri", nil)
@@ -269,7 +265,7 @@ func TestCsrf(t *testing.T) {
 
 		msg := "hello"
 		domain := "example.com"
-		wrappedHandler := csrf(someCsrfHandler(msg), getSecretKey(), domain)
+		wrappedHandler := csrf(someCsrfHandler(msg), tst.SecretKey(), domain)
 
 		reqCsrfTok := id.Random(csrfBytesTokenLength * 2)
 		rec := httptest.NewRecorder()
@@ -298,9 +294,9 @@ func TestCsrf(t *testing.T) {
 
 		msg := "hello"
 		domain := "example.com"
-		wrappedHandler := csrf(someCsrfHandler(msg), getSecretKey(), domain)
+		wrappedHandler := csrf(someCsrfHandler(msg), tst.SecretKey(), domain)
 
-		key := getSecretKey()
+		key := tst.SecretKey()
 		enc2 := cry.New(key)
 		expires := strconv.FormatInt(time.Now().UTC().Add(tokenMaxAge).Unix(), 10)
 		reqCsrfTok := enc2.EncryptEncode(
@@ -371,7 +367,7 @@ func TestCsrf(t *testing.T) {
 
 		msg := "hello"
 		domain := "example.com"
-		wrappedHandler := csrf(someCsrfHandler(msg), getSecretKey(), domain)
+		wrappedHandler := csrf(someCsrfHandler(msg), tst.SecretKey(), domain)
 
 		rec := httptest.NewRecorder()
 		postMsg := "my name is John"
@@ -400,9 +396,9 @@ func TestCsrf(t *testing.T) {
 		domain := "example.com"
 		// for this concurrency test, we have to re-use the same wrappedHandler
 		// so that state is shared and thus we can see if there is any state which is not handled correctly.
-		wrappedHandler := csrf(someCsrfHandler(msg), getSecretKey(), domain)
+		wrappedHandler := csrf(someCsrfHandler(msg), tst.SecretKey(), domain)
 
-		key := getSecretKey()
+		key := tst.SecretKey()
 		enc2 := cry.New(key)
 		expires := strconv.FormatInt(time.Now().UTC().Add(tokenMaxAge).Unix(), 10)
 		reqCsrfTok := enc2.EncryptEncode(

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -39,6 +39,8 @@ const (
 	// An example, is when the Get middleware fails because it has been called with the wrong http method.
 	// Or when the csrf middleware fails because a csrf token was not found for POST/DELETE/etc requests.
 	ongMiddlewareErrorHeader = "Ong-Middleware-Error"
+
+	allowHeader = "Allow"
 )
 
 // Opts are the various parameters(optionals) that can be used to configure middlewares.
@@ -262,6 +264,7 @@ func get(wrappedHandler http.Handler) http.HandlerFunc {
 		if r.Method != http.MethodGet {
 			errMsg := fmt.Sprintf(msg, r.Method)
 			w.Header().Set(ongMiddlewareErrorHeader, errMsg)
+			w.Header().Add(allowHeader, "GET")
 			http.Error(
 				w,
 				errMsg,
@@ -290,6 +293,7 @@ func post(wrappedHandler http.Handler) http.HandlerFunc {
 		if r.Method != http.MethodPost {
 			errMsg := fmt.Sprintf(msg, r.Method)
 			w.Header().Set(ongMiddlewareErrorHeader, errMsg)
+			w.Header().Add(allowHeader, "POST")
 			http.Error(
 				w,
 				errMsg,
@@ -318,6 +322,7 @@ func head(wrappedHandler http.Handler) http.HandlerFunc {
 		if r.Method != http.MethodHead {
 			errMsg := fmt.Sprintf(msg, r.Method)
 			w.Header().Set(ongMiddlewareErrorHeader, errMsg)
+			w.Header().Add(allowHeader, "HEAD")
 			http.Error(
 				w,
 				errMsg,
@@ -346,6 +351,7 @@ func put(wrappedHandler http.Handler) http.HandlerFunc {
 		if r.Method != http.MethodPut {
 			errMsg := fmt.Sprintf(msg, r.Method)
 			w.Header().Set(ongMiddlewareErrorHeader, errMsg)
+			w.Header().Add(allowHeader, "PUT")
 			http.Error(
 				w,
 				errMsg,
@@ -375,6 +381,7 @@ func deleteH(wrappedHandler http.Handler) http.HandlerFunc {
 		if r.Method != http.MethodDelete {
 			errMsg := fmt.Sprintf(msg, r.Method)
 			w.Header().Set(ongMiddlewareErrorHeader, errMsg)
+			w.Header().Add(allowHeader, "DELETE")
 			http.Error(
 				w,
 				errMsg,

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -6,9 +6,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"math"
-	"math/rand"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -16,7 +13,9 @@ import (
 	"testing"
 
 	"github.com/komuw/ong/id"
+	"github.com/komuw/ong/internal/tst"
 	"github.com/komuw/ong/log"
+
 	"go.akshayshah.org/attest"
 	"go.uber.org/goleak"
 	"golang.org/x/exp/slog"
@@ -42,31 +41,6 @@ func someMiddlewareTestHandler(msg string) http.HandlerFunc {
 
 		fmt.Fprint(w, msg)
 	}
-}
-
-// customServer starts a server at a predetermined port.
-// It's upto callers to close the server.
-func customServer(t attest.TB, h http.Handler, domain string, httpsPort uint16) *httptest.Server {
-	t.Helper()
-
-	ts := httptest.NewUnstartedServer(h)
-	ts.Listener.Close()
-
-	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", domain, httpsPort))
-	attest.Ok(t, err)
-
-	ts.Listener = l
-	ts.StartTLS()
-
-	return ts
-}
-
-// getPort returns a random port.
-// The idea is that different tests should run on different independent ports to avoid collisions.
-func getPort() uint16 {
-	r := rand.Intn(10_000) + 1
-	p := math.MaxUint16 - uint16(r)
-	return p
 }
 
 func TestAllMiddleware(t *testing.T) {
@@ -191,11 +165,11 @@ func TestAllMiddleware(t *testing.T) {
 		// non-safe http methods(like POST) require a server-known csrf token;
 		// otherwise it fails with http 403
 		// so here we make a http GET so that we can have a csrf token.
-		httpsPort := getPort()
+		httpsPort := tst.GetPort()
 		domain := "localhost"
 		o := WithOpts(domain, httpsPort, getSecretKey(), DirectIpStrategy, l)
 		wrappedHandler := All(someMiddlewareTestHandler(msg), o)
-		ts := customServer(t, wrappedHandler, "localhost", httpsPort)
+		ts := tst.CustomServer(t, wrappedHandler, "localhost", httpsPort)
 		defer ts.Close()
 
 		res, err := client.Get(ts.URL)
@@ -219,12 +193,12 @@ func TestAllMiddleware(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			httpsPort := getPort()
+			httpsPort := tst.GetPort()
 			domain := "localhost"
 			o := WithOpts(domain, httpsPort, getSecretKey(), DirectIpStrategy, l)
 			wrappedHandler := tt.middleware(someMiddlewareTestHandler(msg), o)
 
-			ts := customServer(t, wrappedHandler, "localhost", httpsPort)
+			ts := tst.CustomServer(t, wrappedHandler, "localhost", httpsPort)
 			defer ts.Close()
 
 			req, err := http.NewRequest(tt.httpMethod, ts.URL, nil)
@@ -267,12 +241,12 @@ func TestMiddlewareServer(t *testing.T) {
 		t.Parallel()
 
 		msg := "hello world"
-		httpsPort := getPort()
+		httpsPort := tst.GetPort()
 		domain := "localhost"
 		o := WithOpts(domain, httpsPort, getSecretKey(), DirectIpStrategy, l)
 		wrappedHandler := All(someMiddlewareTestHandler(msg), o)
 
-		ts := customServer(t, wrappedHandler, domain, httpsPort)
+		ts := tst.CustomServer(t, wrappedHandler, domain, httpsPort)
 		defer ts.Close()
 
 		res, err := client.Get(ts.URL)
@@ -294,13 +268,13 @@ func TestMiddlewareServer(t *testing.T) {
 			// non-safe http methods(like POST) require a server-known csrf token;
 			// otherwise it fails with http 403
 			// so here we make a http GET so that we can have a csrf token.
-			httpsPort := getPort()
+			httpsPort := tst.GetPort()
 			domain := "localhost"
 			o := WithOpts(domain, httpsPort, getSecretKey(), DirectIpStrategy, l)
 			msg := "hey"
 			wrappedHandler := All(someMiddlewareTestHandler(msg), o)
 
-			ts := customServer(t, wrappedHandler, domain, httpsPort)
+			ts := tst.CustomServer(t, wrappedHandler, domain, httpsPort)
 			defer ts.Close()
 
 			res, err := client.Get(ts.URL)
@@ -317,12 +291,12 @@ func TestMiddlewareServer(t *testing.T) {
 		}
 
 		msg := "hello world"
-		httpsPort := getPort()
+		httpsPort := tst.GetPort()
 		domain := "localhost"
 		o := WithOpts(domain, httpsPort, getSecretKey(), DirectIpStrategy, l)
 		wrappedHandler := All(someMiddlewareTestHandler(msg), o)
 
-		ts := customServer(t, wrappedHandler, domain, httpsPort)
+		ts := tst.CustomServer(t, wrappedHandler, domain, httpsPort)
 		defer ts.Close()
 
 		postMsg := "This is a post message"
@@ -375,12 +349,12 @@ func TestMiddlewareServer(t *testing.T) {
 		t.Parallel()
 
 		msg := "hello world"
-		httpsPort := getPort()
+		httpsPort := tst.GetPort()
 		domain := "*.localhost"
 		o := WithOpts(domain, httpsPort, getSecretKey(), DirectIpStrategy, l)
 		wrappedHandler := All(someMiddlewareTestHandler(msg), o)
 
-		ts := customServer(t, wrappedHandler, "localhost", httpsPort)
+		ts := tst.CustomServer(t, wrappedHandler, "localhost", httpsPort)
 		defer ts.Close()
 
 		res, err := client.Get(ts.URL)
@@ -409,7 +383,7 @@ func TestMiddlewareServer(t *testing.T) {
 		logOutput := &bytes.Buffer{}
 		msg := "hello"
 		code := http.StatusAccepted
-		httpsPort := getPort()
+		httpsPort := tst.GetPort()
 		domain := "*.localhost"
 		o := WithOpts(domain, httpsPort, getSecretKey(), DirectIpStrategy, getLogger(logOutput))
 		doubleWrite := func(msg string, code int) http.HandlerFunc {
@@ -420,7 +394,7 @@ func TestMiddlewareServer(t *testing.T) {
 			}
 		}
 		wrappedHandler := All(doubleWrite(msg, code), o)
-		ts := customServer(t, wrappedHandler, "localhost", httpsPort)
+		ts := tst.CustomServer(t, wrappedHandler, "localhost", httpsPort)
 		defer ts.Close()
 
 		req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
@@ -447,14 +421,14 @@ func TestMiddlewareServer(t *testing.T) {
 		t.Parallel()
 
 		msg := "hello world"
-		httpsPort := getPort()
+		httpsPort := tst.GetPort()
 		domain := "localhost"
 		o := WithOpts(domain, httpsPort, getSecretKey(), DirectIpStrategy, l)
 		// for this concurrency test, we have to re-use the same wrappedHandler
 		// so that state is shared and thus we can see if there is any state which is not handled correctly.
 		wrappedHandler := All(someMiddlewareTestHandler(msg), o)
 
-		ts := customServer(t, wrappedHandler, domain, httpsPort)
+		ts := tst.CustomServer(t, wrappedHandler, domain, httpsPort)
 		defer ts.Close()
 
 		runhandler := func() {
@@ -495,12 +469,12 @@ var resultBenchmarkAllMiddlewares int //nolint:gochecknoglobals
 func BenchmarkAllMiddlewares(b *testing.B) {
 	var r int
 	l := log.New(&bytes.Buffer{}, 500)(context.Background())
-	httpsPort := getPort()
+	httpsPort := tst.GetPort()
 	domain := "localhost"
 	o := WithOpts(domain, httpsPort, getSecretKey(), DirectIpStrategy, l)
 	wrappedHandler := All(someBenchmarkAllMiddlewaresHandler(), o)
 
-	ts := customServer(b, wrappedHandler, domain, httpsPort)
+	ts := tst.CustomServer(b, wrappedHandler, domain, httpsPort)
 	defer ts.Close()
 
 	tr := &http.Transport{

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -169,7 +169,7 @@ func TestAllMiddleware(t *testing.T) {
 		domain := "localhost"
 		o := WithOpts(domain, httpsPort, tst.SecretKey(), DirectIpStrategy, l)
 		wrappedHandler := All(someMiddlewareTestHandler(msg), o)
-		ts := tst.CustomServer(t, wrappedHandler, "localhost", httpsPort)
+		ts := tst.TlsServer(t, wrappedHandler, "localhost", httpsPort)
 		defer ts.Close()
 
 		res, err := client.Get(ts.URL)
@@ -198,7 +198,7 @@ func TestAllMiddleware(t *testing.T) {
 			o := WithOpts(domain, httpsPort, tst.SecretKey(), DirectIpStrategy, l)
 			wrappedHandler := tt.middleware(someMiddlewareTestHandler(msg), o)
 
-			ts := tst.CustomServer(t, wrappedHandler, "localhost", httpsPort)
+			ts := tst.TlsServer(t, wrappedHandler, "localhost", httpsPort)
 			defer ts.Close()
 
 			req, err := http.NewRequest(tt.httpMethod, ts.URL, nil)
@@ -246,7 +246,7 @@ func TestMiddlewareServer(t *testing.T) {
 		o := WithOpts(domain, httpsPort, tst.SecretKey(), DirectIpStrategy, l)
 		wrappedHandler := All(someMiddlewareTestHandler(msg), o)
 
-		ts := tst.CustomServer(t, wrappedHandler, domain, httpsPort)
+		ts := tst.TlsServer(t, wrappedHandler, domain, httpsPort)
 		defer ts.Close()
 
 		res, err := client.Get(ts.URL)
@@ -274,7 +274,7 @@ func TestMiddlewareServer(t *testing.T) {
 			msg := "hey"
 			wrappedHandler := All(someMiddlewareTestHandler(msg), o)
 
-			ts := tst.CustomServer(t, wrappedHandler, domain, httpsPort)
+			ts := tst.TlsServer(t, wrappedHandler, domain, httpsPort)
 			defer ts.Close()
 
 			res, err := client.Get(ts.URL)
@@ -296,7 +296,7 @@ func TestMiddlewareServer(t *testing.T) {
 		o := WithOpts(domain, httpsPort, tst.SecretKey(), DirectIpStrategy, l)
 		wrappedHandler := All(someMiddlewareTestHandler(msg), o)
 
-		ts := tst.CustomServer(t, wrappedHandler, domain, httpsPort)
+		ts := tst.TlsServer(t, wrappedHandler, domain, httpsPort)
 		defer ts.Close()
 
 		postMsg := "This is a post message"
@@ -354,7 +354,7 @@ func TestMiddlewareServer(t *testing.T) {
 		o := WithOpts(domain, httpsPort, tst.SecretKey(), DirectIpStrategy, l)
 		wrappedHandler := All(someMiddlewareTestHandler(msg), o)
 
-		ts := tst.CustomServer(t, wrappedHandler, "localhost", httpsPort)
+		ts := tst.TlsServer(t, wrappedHandler, "localhost", httpsPort)
 		defer ts.Close()
 
 		res, err := client.Get(ts.URL)
@@ -394,7 +394,7 @@ func TestMiddlewareServer(t *testing.T) {
 			}
 		}
 		wrappedHandler := All(doubleWrite(msg, code), o)
-		ts := tst.CustomServer(t, wrappedHandler, "localhost", httpsPort)
+		ts := tst.TlsServer(t, wrappedHandler, "localhost", httpsPort)
 		defer ts.Close()
 
 		req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
@@ -428,7 +428,7 @@ func TestMiddlewareServer(t *testing.T) {
 		// so that state is shared and thus we can see if there is any state which is not handled correctly.
 		wrappedHandler := All(someMiddlewareTestHandler(msg), o)
 
-		ts := tst.CustomServer(t, wrappedHandler, domain, httpsPort)
+		ts := tst.TlsServer(t, wrappedHandler, domain, httpsPort)
 		defer ts.Close()
 
 		runhandler := func() {
@@ -474,7 +474,7 @@ func BenchmarkAllMiddlewares(b *testing.B) {
 	o := WithOpts(domain, httpsPort, tst.SecretKey(), DirectIpStrategy, l)
 	wrappedHandler := All(someBenchmarkAllMiddlewaresHandler(), o)
 
-	ts := tst.CustomServer(b, wrappedHandler, domain, httpsPort)
+	ts := tst.TlsServer(b, wrappedHandler, domain, httpsPort)
 	defer ts.Close()
 
 	tr := &http.Transport{

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -167,7 +167,7 @@ func TestAllMiddleware(t *testing.T) {
 		// so here we make a http GET so that we can have a csrf token.
 		httpsPort := tst.GetPort()
 		domain := "localhost"
-		o := WithOpts(domain, httpsPort, getSecretKey(), DirectIpStrategy, l)
+		o := WithOpts(domain, httpsPort, tst.SecretKey(), DirectIpStrategy, l)
 		wrappedHandler := All(someMiddlewareTestHandler(msg), o)
 		ts := tst.CustomServer(t, wrappedHandler, "localhost", httpsPort)
 		defer ts.Close()
@@ -195,7 +195,7 @@ func TestAllMiddleware(t *testing.T) {
 
 			httpsPort := tst.GetPort()
 			domain := "localhost"
-			o := WithOpts(domain, httpsPort, getSecretKey(), DirectIpStrategy, l)
+			o := WithOpts(domain, httpsPort, tst.SecretKey(), DirectIpStrategy, l)
 			wrappedHandler := tt.middleware(someMiddlewareTestHandler(msg), o)
 
 			ts := tst.CustomServer(t, wrappedHandler, "localhost", httpsPort)
@@ -243,7 +243,7 @@ func TestMiddlewareServer(t *testing.T) {
 		msg := "hello world"
 		httpsPort := tst.GetPort()
 		domain := "localhost"
-		o := WithOpts(domain, httpsPort, getSecretKey(), DirectIpStrategy, l)
+		o := WithOpts(domain, httpsPort, tst.SecretKey(), DirectIpStrategy, l)
 		wrappedHandler := All(someMiddlewareTestHandler(msg), o)
 
 		ts := tst.CustomServer(t, wrappedHandler, domain, httpsPort)
@@ -270,7 +270,7 @@ func TestMiddlewareServer(t *testing.T) {
 			// so here we make a http GET so that we can have a csrf token.
 			httpsPort := tst.GetPort()
 			domain := "localhost"
-			o := WithOpts(domain, httpsPort, getSecretKey(), DirectIpStrategy, l)
+			o := WithOpts(domain, httpsPort, tst.SecretKey(), DirectIpStrategy, l)
 			msg := "hey"
 			wrappedHandler := All(someMiddlewareTestHandler(msg), o)
 
@@ -293,7 +293,7 @@ func TestMiddlewareServer(t *testing.T) {
 		msg := "hello world"
 		httpsPort := tst.GetPort()
 		domain := "localhost"
-		o := WithOpts(domain, httpsPort, getSecretKey(), DirectIpStrategy, l)
+		o := WithOpts(domain, httpsPort, tst.SecretKey(), DirectIpStrategy, l)
 		wrappedHandler := All(someMiddlewareTestHandler(msg), o)
 
 		ts := tst.CustomServer(t, wrappedHandler, domain, httpsPort)
@@ -319,7 +319,7 @@ func TestMiddlewareServer(t *testing.T) {
 
 		msg := "hello world"
 		domain := "localhost"
-		o := WithOpts(domain, 443, getSecretKey(), DirectIpStrategy, l)
+		o := WithOpts(domain, 443, tst.SecretKey(), DirectIpStrategy, l)
 		wrappedHandler := All(someMiddlewareTestHandler(msg), o)
 
 		// Should not be a `NewTLSServer` since acme requires HTTP(not HTTPS)
@@ -351,7 +351,7 @@ func TestMiddlewareServer(t *testing.T) {
 		msg := "hello world"
 		httpsPort := tst.GetPort()
 		domain := "*.localhost"
-		o := WithOpts(domain, httpsPort, getSecretKey(), DirectIpStrategy, l)
+		o := WithOpts(domain, httpsPort, tst.SecretKey(), DirectIpStrategy, l)
 		wrappedHandler := All(someMiddlewareTestHandler(msg), o)
 
 		ts := tst.CustomServer(t, wrappedHandler, "localhost", httpsPort)
@@ -385,7 +385,7 @@ func TestMiddlewareServer(t *testing.T) {
 		code := http.StatusAccepted
 		httpsPort := tst.GetPort()
 		domain := "*.localhost"
-		o := WithOpts(domain, httpsPort, getSecretKey(), DirectIpStrategy, getLogger(logOutput))
+		o := WithOpts(domain, httpsPort, tst.SecretKey(), DirectIpStrategy, getLogger(logOutput))
 		doubleWrite := func(msg string, code int) http.HandlerFunc {
 			return func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(code)
@@ -423,7 +423,7 @@ func TestMiddlewareServer(t *testing.T) {
 		msg := "hello world"
 		httpsPort := tst.GetPort()
 		domain := "localhost"
-		o := WithOpts(domain, httpsPort, getSecretKey(), DirectIpStrategy, l)
+		o := WithOpts(domain, httpsPort, tst.SecretKey(), DirectIpStrategy, l)
 		// for this concurrency test, we have to re-use the same wrappedHandler
 		// so that state is shared and thus we can see if there is any state which is not handled correctly.
 		wrappedHandler := All(someMiddlewareTestHandler(msg), o)
@@ -471,7 +471,7 @@ func BenchmarkAllMiddlewares(b *testing.B) {
 	l := log.New(&bytes.Buffer{}, 500)(context.Background())
 	httpsPort := tst.GetPort()
 	domain := "localhost"
-	o := WithOpts(domain, httpsPort, getSecretKey(), DirectIpStrategy, l)
+	o := WithOpts(domain, httpsPort, tst.SecretKey(), DirectIpStrategy, l)
 	wrappedHandler := All(someBenchmarkAllMiddlewaresHandler(), o)
 
 	ts := tst.CustomServer(b, wrappedHandler, domain, httpsPort)
@@ -545,10 +545,10 @@ func TestNew(t *testing.T) {
 			t.Parallel()
 			if tt.expectPanic {
 				attest.Panics(t, func() {
-					New(tt.domain, 443, nil, nil, nil, "super-h@rd-Pa$1word", DirectIpStrategy, slog.Default())
+					New(tt.domain, 443, nil, nil, nil, tst.SecretKey(), DirectIpStrategy, slog.Default())
 				})
 			} else {
-				New(tt.domain, 443, nil, nil, nil, "super-h@rd-Pa$1word", DirectIpStrategy, slog.Default())
+				New(tt.domain, 443, nil, nil, nil, tst.SecretKey(), DirectIpStrategy, slog.Default())
 			}
 		})
 	}

--- a/middleware/redirect_test.go
+++ b/middleware/redirect_test.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/komuw/ong/internal/tst"
+
 	"go.akshayshah.org/attest"
 )
 
@@ -119,11 +121,11 @@ func TestHttpsRedirector(t *testing.T) {
 		t.Parallel()
 
 		msg := "hello world"
-		httpsPort := getPort()
+		httpsPort := tst.GetPort()
 		domain := "localhost"
 		wrappedHandler := httpsRedirector(someHttpsRedirectorHandler(msg), httpsPort, domain)
 
-		ts := customServer(t, wrappedHandler, domain, httpsPort)
+		ts := tst.CustomServer(t, wrappedHandler, domain, httpsPort)
 		defer ts.Close()
 
 		res, err := client.Get(ts.URL)
@@ -145,11 +147,11 @@ func TestHttpsRedirector(t *testing.T) {
 		// as might happen if `httpsRedirector` was using `http.StatusMovedPermanently`
 
 		msg := "hello world"
-		httpsPort := getPort()
+		httpsPort := tst.GetPort()
 		domain := "localhost"
 		wrappedHandler := httpsRedirector(someHttpsRedirectorHandler(msg), httpsPort, domain)
 
-		ts := customServer(t, wrappedHandler, domain, httpsPort)
+		ts := tst.CustomServer(t, wrappedHandler, domain, httpsPort)
 		defer ts.Close()
 
 		postMsg := "my name is John"
@@ -204,11 +206,11 @@ func TestHttpsRedirector(t *testing.T) {
 
 		msg := "hello world"
 
-		httpsPort := getPort()
+		httpsPort := tst.GetPort()
 		domain := "localhost"
 		wrappedHandler := httpsRedirector(someHttpsRedirectorHandler(msg), httpsPort, domain)
 
-		ts := customServer(t, wrappedHandler, domain, httpsPort)
+		ts := tst.CustomServer(t, wrappedHandler, domain, httpsPort)
 		defer ts.Close()
 
 		{

--- a/middleware/redirect_test.go
+++ b/middleware/redirect_test.go
@@ -125,7 +125,7 @@ func TestHttpsRedirector(t *testing.T) {
 		domain := "localhost"
 		wrappedHandler := httpsRedirector(someHttpsRedirectorHandler(msg), httpsPort, domain)
 
-		ts := tst.CustomServer(t, wrappedHandler, domain, httpsPort)
+		ts := tst.TlsServer(t, wrappedHandler, domain, httpsPort)
 		defer ts.Close()
 
 		res, err := client.Get(ts.URL)
@@ -151,7 +151,7 @@ func TestHttpsRedirector(t *testing.T) {
 		domain := "localhost"
 		wrappedHandler := httpsRedirector(someHttpsRedirectorHandler(msg), httpsPort, domain)
 
-		ts := tst.CustomServer(t, wrappedHandler, domain, httpsPort)
+		ts := tst.TlsServer(t, wrappedHandler, domain, httpsPort)
 		defer ts.Close()
 
 		postMsg := "my name is John"
@@ -210,7 +210,7 @@ func TestHttpsRedirector(t *testing.T) {
 		domain := "localhost"
 		wrappedHandler := httpsRedirector(someHttpsRedirectorHandler(msg), httpsPort, domain)
 
-		ts := tst.CustomServer(t, wrappedHandler, domain, httpsPort)
+		ts := tst.TlsServer(t, wrappedHandler, domain, httpsPort)
 		defer ts.Close()
 
 		{

--- a/middleware/session_test.go
+++ b/middleware/session_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/komuw/ong/cookie"
+	"github.com/komuw/ong/internal/tst"
 	"github.com/komuw/ong/sess"
 
 	"go.akshayshah.org/attest"
@@ -67,7 +68,7 @@ func TestSession(t *testing.T) {
 		t.Parallel()
 
 		msg := "hello"
-		secretKey := "super-h@rd-Pa$1word"
+		secretKey := tst.SecretKey()
 		domain := "localhost"
 		key := "name"
 		value := "John Doe"
@@ -91,7 +92,7 @@ func TestSession(t *testing.T) {
 		t.Parallel()
 
 		msg := "hello world wide."
-		secretKey := "super-h@rd-Pa$1word"
+		secretKey := tst.SecretKey()
 		domain := "localhost"
 		key := "name"
 		value := "John Doe"
@@ -139,7 +140,7 @@ func TestSession(t *testing.T) {
 	t.Run("with template variables", func(t *testing.T) {
 		t.Parallel()
 
-		secretKey := "super-h@rd-Pa$1word"
+		secretKey := tst.SecretKey()
 		domain := "localhost"
 		name := "John Doe"
 		wrappedHandler := session(templateVarsHandler(t, name), secretKey, domain)
@@ -166,7 +167,7 @@ func TestSession(t *testing.T) {
 		t.Parallel()
 
 		msg := "hello"
-		secretKey := "super-h@rd-Pa$1word"
+		secretKey := tst.SecretKey()
 		domain := "localhost"
 		key := "name"
 		value := "John Doe"

--- a/mux/mux_test.go
+++ b/mux/mux_test.go
@@ -203,8 +203,8 @@ func TestMux(t *testing.T) {
 			rStr := fmt.Sprintf("%v", r)
 			attest.Subsequence(t, rStr, uri2)
 			attest.Subsequence(t, rStr, method)
-			attest.Subsequence(t, rStr, "ong/mux/mux_test.go:32") // location where `someMuxHandler` is declared.
-			attest.Subsequence(t, rStr, "ong/mux/mux_test.go:38") // location where `thisIsAnotherMuxHandler` is declared.
+			attest.Subsequence(t, rStr, "ong/mux/mux_test.go:27") // location where `someMuxHandler` is declared.
+			attest.Subsequence(t, rStr, "ong/mux/mux_test.go:33") // location where `thisIsAnotherMuxHandler` is declared.
 		}()
 
 		_ = New(
@@ -257,28 +257,28 @@ func TestMux(t *testing.T) {
 				"api",
 				"/api/",
 				MethodGet,
-				"ong/mux/mux_test.go:32", // location where `someMuxHandler` is declared.
+				"ong/mux/mux_test.go:27", // location where `someMuxHandler` is declared.
 			},
 			{
 				"success with prefix slash",
 				"/api",
 				"/api/",
 				MethodGet,
-				"ong/mux/mux_test.go:32", // location where `someMuxHandler` is declared.
+				"ong/mux/mux_test.go:27", // location where `someMuxHandler` is declared.
 			},
 			{
 				"success with suffix slash",
 				"api/",
 				"/api/",
 				MethodGet,
-				"ong/mux/mux_test.go:32", // location where `someMuxHandler` is declared.
+				"ong/mux/mux_test.go:27", // location where `someMuxHandler` is declared.
 			},
 			{
 				"success with all slashes",
 				"/api/",
 				"/api/",
 				MethodGet,
-				"ong/mux/mux_test.go:32", // location where `someMuxHandler` is declared.
+				"ong/mux/mux_test.go:27", // location where `someMuxHandler` is declared.
 			},
 			{
 				"bad",
@@ -292,14 +292,14 @@ func TestMux(t *testing.T) {
 				"check/2625",
 				"/check/:age/",
 				MethodAll,
-				"ong/mux/mux_test.go:44", // location where `checkAgeHandler` is declared.
+				"ong/mux/mux_test.go:39", // location where `checkAgeHandler` is declared.
 			},
 			{
 				"url with domain name",
 				"https://localhost/check/2625",
 				"/check/:age/",
 				MethodAll,
-				"ong/mux/mux_test.go:44", // location where `checkAgeHandler` is declared.
+				"ong/mux/mux_test.go:39", // location where `checkAgeHandler` is declared.
 			},
 		}
 

--- a/mux/mux_test.go
+++ b/mux/mux_test.go
@@ -127,7 +127,7 @@ func TestMux(t *testing.T) {
 			),
 		)
 
-		ts := tst.CustomServer(t, mux, domain, httpsPort)
+		ts := tst.TlsServer(t, mux, domain, httpsPort)
 		defer ts.Close()
 
 		csrfToken := ""
@@ -172,7 +172,7 @@ func TestMux(t *testing.T) {
 			),
 		)
 
-		ts := tst.CustomServer(t, mux, domain, httpsPort)
+		ts := tst.TlsServer(t, mux, domain, httpsPort)
 		defer ts.Close()
 
 		res, err := client.Get(ts.URL + uri)

--- a/mux/mux_test.go
+++ b/mux/mux_test.go
@@ -23,11 +23,6 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }
 
-func getSecretKey() string {
-	key := "super-h@rd-Pa$1word"
-	return key
-}
-
 func someMuxHandler(msg string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, msg)
@@ -73,7 +68,7 @@ func TestNewRoute(t *testing.T) {
 			MethodGet,
 			middleware.Get(
 				someMuxHandler("msg"),
-				middleware.WithOpts("localhost", 443, getSecretKey(), middleware.DirectIpStrategy, l),
+				middleware.WithOpts("localhost", 443, tst.SecretKey(), middleware.DirectIpStrategy, l),
 			),
 		)
 	})
@@ -95,7 +90,7 @@ func TestMux(t *testing.T) {
 		msg := "hello world"
 		mux := New(
 			l,
-			middleware.WithOpts("localhost", 443, getSecretKey(), middleware.DirectIpStrategy, l),
+			middleware.WithOpts("localhost", 443, tst.SecretKey(), middleware.DirectIpStrategy, l),
 			nil,
 			NewRoute(
 				"/api",
@@ -123,7 +118,7 @@ func TestMux(t *testing.T) {
 		domain := "localhost"
 		mux := New(
 			l,
-			middleware.WithOpts(domain, httpsPort, getSecretKey(), middleware.DirectIpStrategy, l),
+			middleware.WithOpts(domain, httpsPort, tst.SecretKey(), middleware.DirectIpStrategy, l),
 			nil,
 			NewRoute(
 				uri,
@@ -168,7 +163,7 @@ func TestMux(t *testing.T) {
 		domain := "localhost"
 		mux := New(
 			l,
-			middleware.WithOpts(domain, httpsPort, getSecretKey(), middleware.DirectIpStrategy, l),
+			middleware.WithOpts(domain, httpsPort, tst.SecretKey(), middleware.DirectIpStrategy, l),
 			nil,
 			NewRoute(
 				uri,
@@ -214,7 +209,7 @@ func TestMux(t *testing.T) {
 
 		_ = New(
 			l,
-			middleware.WithOpts("localhost", 443, getSecretKey(), middleware.DirectIpStrategy, l),
+			middleware.WithOpts("localhost", 443, tst.SecretKey(), middleware.DirectIpStrategy, l),
 			nil,
 			NewRoute(
 				uri1,
@@ -236,7 +231,7 @@ func TestMux(t *testing.T) {
 		expectedHandler := someMuxHandler(msg)
 		mux := New(
 			l,
-			middleware.WithOpts("localhost", 443, getSecretKey(), middleware.DirectIpStrategy, l),
+			middleware.WithOpts("localhost", 443, tst.SecretKey(), middleware.DirectIpStrategy, l),
 			nil,
 			NewRoute(
 				"/api",
@@ -353,7 +348,7 @@ func BenchmarkMuxNew(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		mux := New(
 			l,
-			middleware.WithOpts("localhost", 443, getSecretKey(), middleware.DirectIpStrategy, l),
+			middleware.WithOpts("localhost", 443, tst.SecretKey(), middleware.DirectIpStrategy, l),
 			nil,
 			getManyRoutes()...,
 		)

--- a/mux/mux_test.go
+++ b/mux/mux_test.go
@@ -208,8 +208,8 @@ func TestMux(t *testing.T) {
 			rStr := fmt.Sprintf("%v", r)
 			attest.Subsequence(t, rStr, uri2)
 			attest.Subsequence(t, rStr, method)
-			attest.Subsequence(t, rStr, "ong/mux/mux_test.go:34") // location where `someMuxHandler` is declared.
-			attest.Subsequence(t, rStr, "ong/mux/mux_test.go:40") // location where `thisIsAnotherMuxHandler` is declared.
+			attest.Subsequence(t, rStr, "ong/mux/mux_test.go:32") // location where `someMuxHandler` is declared.
+			attest.Subsequence(t, rStr, "ong/mux/mux_test.go:38") // location where `thisIsAnotherMuxHandler` is declared.
 		}()
 
 		_ = New(
@@ -262,28 +262,28 @@ func TestMux(t *testing.T) {
 				"api",
 				"/api/",
 				MethodGet,
-				"ong/mux/mux_test.go:34", // location where `someMuxHandler` is declared.
+				"ong/mux/mux_test.go:32", // location where `someMuxHandler` is declared.
 			},
 			{
 				"success with prefix slash",
 				"/api",
 				"/api/",
 				MethodGet,
-				"ong/mux/mux_test.go:34", // location where `someMuxHandler` is declared.
+				"ong/mux/mux_test.go:32", // location where `someMuxHandler` is declared.
 			},
 			{
 				"success with suffix slash",
 				"api/",
 				"/api/",
 				MethodGet,
-				"ong/mux/mux_test.go:34", // location where `someMuxHandler` is declared.
+				"ong/mux/mux_test.go:32", // location where `someMuxHandler` is declared.
 			},
 			{
 				"success with all slashes",
 				"/api/",
 				"/api/",
 				MethodGet,
-				"ong/mux/mux_test.go:34", // location where `someMuxHandler` is declared.
+				"ong/mux/mux_test.go:32", // location where `someMuxHandler` is declared.
 			},
 			{
 				"bad",
@@ -297,14 +297,14 @@ func TestMux(t *testing.T) {
 				"check/2625",
 				"/check/:age/",
 				MethodAll,
-				"ong/mux/mux_test.go:46", // location where `checkAgeHandler` is declared.
+				"ong/mux/mux_test.go:44", // location where `checkAgeHandler` is declared.
 			},
 			{
 				"url with domain name",
 				"https://localhost/check/2625",
 				"/check/:age/",
 				MethodAll,
-				"ong/mux/mux_test.go:46", // location where `checkAgeHandler` is declared.
+				"ong/mux/mux_test.go:44", // location where `checkAgeHandler` is declared.
 			},
 		}
 

--- a/server/pprof_test.go
+++ b/server/pprof_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/komuw/ong/internal/tst"
 	"github.com/komuw/ong/log"
 
 	"go.akshayshah.org/attest"
@@ -26,7 +27,7 @@ func TestPprofServer(t *testing.T) {
 		startPprofServer(l, o)
 
 		// await for the server to start.
-		ping(t, uint16(port))
+		tst.Ping(t, uint16(port))
 
 		uri := "/debug/pprof/heap"
 		res, err := http.Get(fmt.Sprintf("http://localhost:%d%s", port, uri))
@@ -42,7 +43,7 @@ func TestPprofServer(t *testing.T) {
 		startPprofServer(l, o)
 
 		// await for the server to start.
-		ping(t, uint16(port))
+		tst.Ping(t, uint16(port))
 
 		runhandler := func() {
 			uri := "/debug/pprof/heap"

--- a/sess/sess_test.go
+++ b/sess/sess_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/komuw/ong/internal/tst"
 	"go.akshayshah.org/attest"
 	"go.uber.org/goleak"
 )
@@ -13,11 +14,6 @@ import (
 func TestMain(m *testing.M) {
 	// call flag.Parse() here if TestMain uses flags
 	goleak.VerifyTestMain(m)
-}
-
-func getSecretKey() string {
-	key := "super-h@rd-Pa$1word"
-	return key
 }
 
 func TestSess(t *testing.T) {
@@ -28,7 +24,7 @@ func TestSess(t *testing.T) {
 
 		req, err := http.NewRequest(http.MethodGet, "/someUri", nil)
 		attest.Ok(t, err)
-		req = Initialise(req, getSecretKey())
+		req = Initialise(req, tst.SecretKey())
 
 		res := req.Context().Value(ctxKey).(map[string]string)
 		attest.Equal(t, res, map[string]string{})
@@ -42,7 +38,7 @@ func TestSess(t *testing.T) {
 
 		req, err := http.NewRequest(http.MethodGet, "/someUri", nil)
 		attest.Ok(t, err)
-		req = Initialise(req, getSecretKey())
+		req = Initialise(req, tst.SecretKey())
 
 		Set(req, k, v)
 		res := req.Context().Value(ctxKey).(map[string]string)
@@ -56,7 +52,7 @@ func TestSess(t *testing.T) {
 
 		req, err := http.NewRequest(http.MethodGet, "/someUri", nil)
 		attest.Ok(t, err)
-		req = Initialise(req, getSecretKey())
+		req = Initialise(req, tst.SecretKey())
 
 		SetM(req, m)
 		res := req.Context().Value(ctxKey).(map[string]string)
@@ -70,7 +66,7 @@ func TestSess(t *testing.T) {
 		v := "John Keypoole"
 		req, err := http.NewRequest(http.MethodGet, "/someUri", nil)
 		attest.Ok(t, err)
-		req = Initialise(req, getSecretKey())
+		req = Initialise(req, tst.SecretKey())
 
 		{
 			one := Get(req, k)
@@ -93,7 +89,7 @@ func TestSess(t *testing.T) {
 		m := M{"name": "John Doe", "age": "99"}
 		req, err := http.NewRequest(http.MethodGet, "/someUri", nil)
 		attest.Ok(t, err)
-		req = Initialise(req, getSecretKey())
+		req = Initialise(req, tst.SecretKey())
 
 		{
 			one := GetM(req)
@@ -126,7 +122,7 @@ func TestSess(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "/someUri", nil)
 		attest.Ok(t, err)
 		rec := httptest.NewRecorder()
-		req = Initialise(req, getSecretKey())
+		req = Initialise(req, tst.SecretKey())
 
 		{
 			SetM(req, m)
@@ -134,7 +130,7 @@ func TestSess(t *testing.T) {
 			attest.Equal(t, res, m)
 		}
 		{
-			Save(req, rec, "localhost", 2*time.Hour, getSecretKey())
+			Save(req, rec, "localhost", 2*time.Hour, tst.SecretKey())
 		}
 	})
 }


### PR DESCRIPTION
- This is mandated by the spec

- Fixes: https://github.com/komuw/ong/issues/339
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Allow