### PR TITLE
issues/341: Return http 404 instead of 400 for bad host header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Most recent version is listed first.
 - ong/middleware: Fix DNS rebinding via http: https://github.com/komuw/ong/compare/issues/337
 - And test util: https://github.com/komuw/ong/pull/344
 - ong/middleware: Send Allow http header when we respond with http 405 status code: https://github.com/komuw/ong/pull/345
+- ong/middleware: Return http 404 instead of 400 for bad host header: https://github.com/komuw/ong/pull/346
 
 # v0.0.70
 - ong/server: Dynamically assign port for pprof: https://github.com/komuw/ong/pull/343

--- a/middleware/redirect.go
+++ b/middleware/redirect.go
@@ -71,7 +71,7 @@ func httpsRedirector(wrappedHandler http.Handler, httpsPort uint16, domain strin
 				http.Error(
 					w,
 					err.Error(),
-					http.StatusBadRequest,
+					http.StatusNotFound,
 				)
 				return
 			}

--- a/middleware/redirect_test.go
+++ b/middleware/redirect_test.go
@@ -281,7 +281,7 @@ func TestHttpsRedirector(t *testing.T) {
 			{
 				name:         "bad host",
 				host:         "example.com",
-				expectedCode: http.StatusBadRequest,
+				expectedCode: http.StatusNotFound,
 				expectedMsg:  "has an unexpected value",
 			},
 		}


### PR DESCRIPTION
- This is what example.com and google.com does.
- This also means that we also do not have to pollute logs with it; https://github.com/komuw/ong/blob/46c45d146b6f7277922413fc30de1e4f34f2383c/middleware/log.go#L65-L72

- Fixes: https://github.com/komuw/ong/issues/341