### PR TITLE
ong/id: Use crypto/rand in id.New()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Most recent version is listed first.
 - And test util: https://github.com/komuw/ong/pull/344
 - ong/middleware: Send Allow http header when we respond with http 405 status code: https://github.com/komuw/ong/pull/345
 - ong/middleware: Return http 404 instead of 400 for bad host header: https://github.com/komuw/ong/pull/346
+- ong/id: Use crypto/rand in id.New(): https://github.com/komuw/ong/pull/347
 
 # v0.0.70
 - ong/server: Dynamically assign port for pprof: https://github.com/komuw/ong/pull/343

--- a/id/id.go
+++ b/id/id.go
@@ -2,8 +2,8 @@
 package id
 
 import (
+	"crypto/rand"
 	"encoding/base64"
-	mathRand "math/rand"
 )
 
 // encodeURL is like [base64.EncodeURL] except we replace:
@@ -21,18 +21,23 @@ func encoding() *base64.Encoding {
 
 var enc = encoding() //nolint:gochecknoglobals
 
-// New returns a new random string.
-// It uses a character set that is legible.
-// It should not be used for cryptography purposes.
+// New returns a new random string consisting of a legible character set.
+// It uses [rand]
+//
+// Also see [UUID4] and [UUID8]
+//
+// It panics on error.
 func New() string {
 	return Random(16)
 }
 
-// Random generates a random string of size n.
-// It uses a character set that is legible.
+// Random generates a random string of size n consisting of a legible character set.
 // If n < 1 or significantly large, it is set to reasonable bounds.
+// It uses [rand]
 //
-// It should not be used for cryptography purposes.
+// Also see [UUID4] and [UUID8]
+//
+// It panics on error.
 func Random(n int) string {
 	if n < 1 {
 		n = 1
@@ -46,10 +51,10 @@ func Random(n int) string {
 	// This formula is from [base64.Encoding.EncodedLen]
 	byteSize := ((((n * 6) - 5) / 8) + 1)
 	b := make([]byte, byteSize)
-	//lint:ignore SA1019 `mathRand.Read` is deprecated.
-	// However, for our case here is okay since the func id.Random is not used for cryptography.
-	// Also we like the property of `mathRand.Read` always returning a nil error.
-	_, _ = mathRand.Read(b) // nolint:staticcheck
+
+	if _, err := rand.Read(b); err != nil {
+		panic(err)
+	}
 
 	return enc.EncodeToString(b)[:n]
 }

--- a/id/uuid.go
+++ b/id/uuid.go
@@ -21,7 +21,7 @@ const (
 //   uuidv7: https://datatracker.ietf.org/doc/html/draft-ietf-uuidrev-rfc4122bis
 
 // UUID represents a universally unique identifier.
-// See [UUID4] and [UUID8]
+// Also see [UUID4] and [UUID8]
 //
 // [unique]: https://en.wikipedia.org/wiki/Universally_unique_identifier
 type UUID [16]byte
@@ -52,7 +52,7 @@ func (u *UUID) setVersion(version byte) {
 // It is not correlated with timestamp, thus, when used as the identifief of an object, it does not leak its creation time.
 // On the other hand, this means that it has poor database index locality unlike [UUID8]. It might also be a good use as a shard key.
 //
-// See [UUID8] and [New]
+// Also see [UUID8] and [New]
 //
 // It panics on error.
 func UUID4() UUID {
@@ -92,7 +92,7 @@ func UUID4() UUID {
 // It is correlated with timestamp, thus, when used as the identifief of an object, it has good database locality.
 // On the other hand, this means that it can leak the object's creation time unlike [UUID4].
 //
-// See [UUID4] and [New]
+// Also see [UUID4] and [New]
 //
 // It panics on error.
 //


### PR DESCRIPTION
- Initially, `id.New()` was for use in non-cryptographic usecases.
  However, I've noticed that I tend to reach for it even in cryptographic circumstances because of its ease of use.
  This PR formalizes that usecase.
- This undoes https://github.com/komuw/ong/pull/322