### PR TITLE
Remove logger from mux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Most recent version is listed first.
 # v0.0.77
 - ong/middleware: Add support for http.NewResponseController: https://github.com/komuw/ong/pull/368
 - ong/middleware: Improve formatting of some types: https://github.com/komuw/ong/pull/370
+- ong/mux: Remove logger from mux: https://github.com/komuw/ong/pull/371
 
 # v0.0.76
 - ong/middleware: Configure what percentage of ratelimited or loadshed responses should be logged: https://github.com/komuw/ong/pull/364

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ func main() {
 	l := log.New(context.Background(), os.Stdout, 1000)
 	secretKey := "super-h@rd-Pa$1word"
 	mux := mux.New(
-		l,
 		middleware.WithOpts(
 			"localhost",
 			65081,

--- a/example/main.go
+++ b/example/main.go
@@ -16,7 +16,6 @@ func main() {
 
 	api := NewApp(myDB{map[string]string{}}, l)
 	mux := mux.New(
-		l,
 		middleware.WithOpts("localhost", 65081, secretKey, middleware.DirectIpStrategy, l),
 		nil,
 		mux.NewRoute(

--- a/mux/example_test.go
+++ b/mux/example_test.go
@@ -24,7 +24,7 @@ func BooksByAuthorHandler() http.HandlerFunc {
 	}
 }
 
-func ExampleMux() {
+func ExampleMuxer() {
 	l := log.New(context.Background(), os.Stdout, 1000)
 	mux := mux.New(
 		middleware.WithOpts("localhost", 8080, "super-h@rd-Pa$1word", middleware.DirectIpStrategy, l),
@@ -51,7 +51,7 @@ func ExampleMux() {
 	}
 }
 
-func ExampleMux_Resolve() {
+func ExampleMuxer_Resolve() {
 	l := log.New(context.Background(), os.Stdout, 1000)
 	mux := mux.New(
 		middleware.WithOpts("localhost", 8080, "super-h@rd-Pa$1word", middleware.DirectIpStrategy, l),

--- a/mux/example_test.go
+++ b/mux/example_test.go
@@ -27,7 +27,6 @@ func BooksByAuthorHandler() http.HandlerFunc {
 func ExampleMux() {
 	l := log.New(context.Background(), os.Stdout, 1000)
 	mux := mux.New(
-		l,
 		middleware.WithOpts("localhost", 8080, "super-h@rd-Pa$1word", middleware.DirectIpStrategy, l),
 		nil,
 		mux.NewRoute(
@@ -55,7 +54,6 @@ func ExampleMux() {
 func ExampleMux_Resolve() {
 	l := log.New(context.Background(), os.Stdout, 1000)
 	mux := mux.New(
-		l,
 		middleware.WithOpts("localhost", 8080, "super-h@rd-Pa$1word", middleware.DirectIpStrategy, l),
 		nil,
 		mux.NewRoute(

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -49,19 +49,19 @@ func NewRoute(
 	}
 }
 
-// Mux is a HTTP request multiplexer.
+// Muxer is a HTTP request multiplexer.
 //
 // It matches the URL of each incoming request against a list of registered
 // patterns and calls the handler for the pattern that most closely matches the URL.
 // It implements http.Handler
 //
-// Use [New] to get a valid Mux.
-type Mux struct {
+// Use [New] to get a valid Muxer.
+type Muxer struct {
 	router *router // some router
 }
 
 // String implements [fmt.Stringer]
-func (m Mux) String() string {
+func (m Muxer) String() string {
 	return fmt.Sprintf(`Opts{
   router: %v
 }`,
@@ -70,7 +70,7 @@ func (m Mux) String() string {
 }
 
 // GoString implements [fmt.GoStringer]
-func (m Mux) GoString() string {
+func (m Muxer) GoString() string {
 	return m.String()
 }
 
@@ -83,8 +83,8 @@ func (m Mux) GoString() string {
 // Typically, an application should only have one Mux.
 //
 // It panics with a helpful error message if it detects conflicting routes.
-func New(opt middleware.Opts, notFoundHandler http.Handler, routes ...Route) Mux {
-	m := Mux{
+func New(opt middleware.Opts, notFoundHandler http.Handler, routes ...Route) Muxer {
+	m := Muxer{
 		router: newRouter(notFoundHandler),
 	}
 
@@ -133,14 +133,14 @@ func New(opt middleware.Opts, notFoundHandler http.Handler, routes ...Route) Mux
 	return m
 }
 
-func (m Mux) addPattern(method, pattern string, originalHandler, wrappingHandler http.Handler) {
+func (m Muxer) addPattern(method, pattern string, originalHandler, wrappingHandler http.Handler) {
 	m.router.handle(method, pattern, originalHandler, wrappingHandler)
 }
 
 // ServeHTTP implements a http.Handler
 //
 // It routes incoming http requests based on method and path extracting path parameters as it goes.
-func (m Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (m Muxer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	m.router.serveHTTP(w, r)
 }
 
@@ -151,7 +151,7 @@ func (m Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // It is inspired by django's [resolve] url utility.
 //
 // [resolve]: https://docs.djangoproject.com/en/4.2/ref/urlresolvers/#django.urls.resolve
-func (m Mux) Resolve(path string) Route {
+func (m Muxer) Resolve(path string) Route {
 	zero := Route{}
 
 	u, err := url.Parse(path)

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -4,7 +4,6 @@ package mux
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -58,7 +57,6 @@ func NewRoute(
 //
 // Use [New] to get a valid Mux.
 type Mux struct {
-	l      *slog.Logger
 	router *router // some router
 }
 
@@ -85,9 +83,8 @@ func (m Mux) GoString() string {
 // Typically, an application should only have one Mux.
 //
 // It panics with a helpful error message if it detects conflicting routes.
-func New(l *slog.Logger, opt middleware.Opts, notFoundHandler http.Handler, routes ...Route) Mux {
+func New(opt middleware.Opts, notFoundHandler http.Handler, routes ...Route) Mux {
 	m := Mux{
-		l:      l,
 		router: newRouter(notFoundHandler),
 	}
 

--- a/mux/mux_test.go
+++ b/mux/mux_test.go
@@ -333,10 +333,10 @@ func getManyRoutes() []Route {
 	return routes
 }
 
-var result Mux //nolint:gochecknoglobals
+var result Muxer //nolint:gochecknoglobals
 
 func BenchmarkMuxNew(b *testing.B) {
-	var r Mux
+	var r Muxer
 
 	l := log.New(context.Background(), &bytes.Buffer{}, 500)
 

--- a/mux/mux_test.go
+++ b/mux/mux_test.go
@@ -89,7 +89,6 @@ func TestMux(t *testing.T) {
 
 		msg := "hello world"
 		mux := New(
-			l,
 			middleware.WithOpts("localhost", 443, tst.SecretKey(), middleware.DirectIpStrategy, l),
 			nil,
 			NewRoute(
@@ -117,7 +116,6 @@ func TestMux(t *testing.T) {
 		httpsPort := tst.GetPort()
 		domain := "localhost"
 		mux := New(
-			l,
 			middleware.WithOpts(domain, httpsPort, tst.SecretKey(), middleware.DirectIpStrategy, l),
 			nil,
 			NewRoute(
@@ -163,7 +161,6 @@ func TestMux(t *testing.T) {
 		httpsPort := tst.GetPort()
 		domain := "localhost"
 		mux := New(
-			l,
 			middleware.WithOpts(domain, httpsPort, tst.SecretKey(), middleware.DirectIpStrategy, l),
 			nil,
 			NewRoute(
@@ -210,7 +207,6 @@ func TestMux(t *testing.T) {
 		}()
 
 		_ = New(
-			l,
 			middleware.WithOpts("localhost", 443, tst.SecretKey(), middleware.DirectIpStrategy, l),
 			nil,
 			NewRoute(
@@ -232,7 +228,6 @@ func TestMux(t *testing.T) {
 		msg := "hello world"
 		expectedHandler := someMuxHandler(msg)
 		mux := New(
-			l,
 			middleware.WithOpts("localhost", 443, tst.SecretKey(), middleware.DirectIpStrategy, l),
 			nil,
 			NewRoute(
@@ -349,7 +344,6 @@ func BenchmarkMuxNew(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		mux := New(
-			l,
 			middleware.WithOpts("localhost", 443, tst.SecretKey(), middleware.DirectIpStrategy, l),
 			nil,
 			getManyRoutes()...,

--- a/server/example_test.go
+++ b/server/example_test.go
@@ -16,7 +16,6 @@ func ExampleRun() {
 	l := log.New(context.Background(), os.Stdout, 1000)
 	secretKey := "super-h@rd-Pa$1word"
 	mux := mux.New(
-		l,
 		middleware.WithOpts(
 			"localhost",
 			65081,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -166,7 +166,6 @@ func TestServer(t *testing.T) {
 		uri := "/api"
 		msg := "hello world"
 		mux := mux.New(
-			l,
 			middleware.WithOpts("localhost", port, tst.SecretKey(), middleware.DirectIpStrategy, l),
 			nil,
 			mux.NewRoute(
@@ -269,7 +268,6 @@ func TestServer(t *testing.T) {
 		uri := "/api"
 		msg := "hello world"
 		mux := mux.New(
-			l,
 			middleware.WithOpts("localhost", port, tst.SecretKey(), middleware.DirectIpStrategy, l),
 			nil,
 			mux.NewRoute(
@@ -336,7 +334,6 @@ func TestServer(t *testing.T) {
 		uri := "/api"
 		msg := "hello world"
 		mux := mux.New(
-			l,
 			middleware.WithOpts("localhost", port, tst.SecretKey(), middleware.DirectIpStrategy, l),
 			nil,
 			mux.NewRoute(


### PR DESCRIPTION
- The muxer did not need the logger
- Also rename mux.Mux to mux.Muxer. This reduces some stuttering.