### PR TITLE
Add config.secureKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Most recent version is listed first.
 - ong/mux: Remove logger from mux: https://github.com/komuw/ong/pull/371
 - ong/mux: Add internal/mux: https://github.com/komuw/ong/pull/372
 - ong/config: Create common config options: https://github.com/komuw/ong/pull/374
+- ong/config: Add config.secureKey: https://github.com/komuw/ong/pull/376
 
 # v0.0.76
 - ong/middleware: Configure what percentage of ratelimited or loadshed responses should be logged: https://github.com/komuw/ong/pull/364

--- a/config/config.go
+++ b/config/config.go
@@ -122,6 +122,8 @@ type Opts struct {
 	serverOpts
 }
 
+// TODO: add test showing that secretKey is not logged as is(without masking)
+
 // String implements [fmt.Stringer]
 func (o Opts) String() string {
 	return fmt.Sprintf(`Opts{
@@ -228,7 +230,7 @@ func New(
 	drainTimeout time.Duration,
 	certFile string,
 	keyFile string,
-	acmeEmail string, // if present, tls will be served from acme certificates.
+	acmeEmail string,
 	acmeDirectoryUrl string,
 	clientCertificatePool *x509.CertPool,
 ) Opts {
@@ -440,11 +442,31 @@ func LetsEncryptOpts(
 	}
 }
 
+// secureKey is a custom string that does not reveal its content when printed.
+type secureKey string
+
+// String implements [fmt.Stringer]
+func (s secureKey) String() string {
+	if len(s) <= 0 {
+		return "secureKey(<EMPTY>)"
+	}
+	return fmt.Sprintf("secureKey(%s<REDACTED>)", string(s[0]))
+}
+
+// GoString implements [fmt.GoStringer]
+func (s secureKey) GoString() string {
+	return s.String()
+}
+
 // middlewareOpts are parameters that are used by middleware.
 type middlewareOpts struct {
 	Domain    string
 	HttpsPort uint16
-	SecretKey string
+	// When printing a struct, fmt does not invoke custom formatting methods on unexported fields.
+	// We thus need to make this field to be exported.
+	// - https://pkg.go.dev/fmt#:~:text=When%20printing%20a%20struct
+	// - https://go.dev/play/p/wL2gqumZ23b
+	SecretKey secureKey
 	Strategy  ClientIPstrategy
 	Logger    *slog.Logger
 
@@ -494,7 +516,7 @@ func (m middlewareOpts) String() string {
 }`,
 		m.Domain,
 		m.HttpsPort,
-		fmt.Sprintf("%s<REDACTED>", string(m.SecretKey[0])),
+		m.SecretKey,
 		m.Strategy,
 		m.Logger,
 		m.RateShedSamplePercent,
@@ -551,7 +573,7 @@ func newMiddlewareOpts(
 	return middlewareOpts{
 		Domain:    domain,
 		HttpsPort: httpsPort,
-		SecretKey: secretKey,
+		SecretKey: secureKey(secretKey),
 		Strategy:  strategy,
 		Logger:    logger,
 

--- a/config/config.go
+++ b/config/config.go
@@ -122,8 +122,6 @@ type Opts struct {
 	serverOpts
 }
 
-// TODO: add test showing that secretKey is not logged as is(without masking)
-
 // String implements [fmt.Stringer]
 func (o Opts) String() string {
 	return fmt.Sprintf(`Opts{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -111,7 +111,7 @@ func TestOpts(t *testing.T) {
 			middlewareOpts: middlewareOpts{
 				Domain:                 "localhost",
 				HttpsPort:              65081,
-				SecretKey:              tst.SecretKey(),
+				SecretKey:              secureKey(tst.SecretKey()),
 				Strategy:               clientip.DirectIpStrategy,
 				Logger:                 l,
 				RateShedSamplePercent:  DefaultRateShedSamplePercent,
@@ -153,6 +153,10 @@ func TestOpts(t *testing.T) {
 		}
 
 		attest.Equal(t, got, want)
+
+		attest.Subsequence(t, got.SecretKey.String(), "REDACTED")
+		attest.Subsequence(t, got.String(), "REDACTED")
+		attest.Subsequence(t, got.GoString(), "REDACTED")
 	})
 
 	// t.Run("with opts", func(t *testing.T) {

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -134,13 +134,13 @@ func allDefaultMiddlewares(
 													reloadProtector(
 														session(
 															wrappedHandler,
-															secretKey,
+															string(secretKey),
 															domain,
 															sessionCookieDuration,
 														),
 														domain,
 													),
-													secretKey,
+													string(secretKey),
 													domain,
 													csrfTokenDuration,
 												),


### PR DESCRIPTION
- This is needed to try and prevent inadvertent logging/printing of the secure key