### PR TITLE
issues/365: Do not use IP address and TLS fingerprint to validate cookies by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Most recent version is listed first.  
 
 
+# v0.0.83
+- ong/cookies: Do not use IP address and TLS fingerprint to validate cookies by default: https://github.com/komuw/ong/pull/388
+
 # v0.0.82
 - ong/config: Move middleware.ClientIPstrategy to config.ClientIPstrategy: https://github.com/komuw/ong/pull/386
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -73,6 +73,7 @@ func TestNewMiddlewareOpts(t *testing.T) {
 						DefaultCorsCacheDuration,
 						DefaultCsrfCookieDuration,
 						DefaultSessionCookieDuration,
+						DefaultSessionAntiReplyFunc,
 					)
 				})
 			} else {
@@ -94,6 +95,7 @@ func TestNewMiddlewareOpts(t *testing.T) {
 					DefaultCorsCacheDuration,
 					DefaultCsrfCookieDuration,
 					DefaultSessionCookieDuration,
+					DefaultSessionAntiReplyFunc,
 				)
 			}
 		})
@@ -127,6 +129,7 @@ func TestOpts(t *testing.T) {
 				CorsCacheDuration:      DefaultCorsCacheDuration,
 				CsrfTokenDuration:      DefaultCsrfCookieDuration,
 				SessionCookieDuration:  DefaultSessionCookieDuration,
+				SessionAntiReplyFunc:   DefaultSessionAntiReplyFunc,
 			},
 
 			serverOpts: serverOpts{

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -56,6 +56,8 @@ func ExampleNew() {
 		3*24*time.Hour,
 		// Expire session cookie after 6hours.
 		6*time.Hour,
+		// Use a given header to try and mitigate against replay-attacks.
+		func(r *http.Request) string { return r.Header.Get("Anti-Replay") },
 		//
 		// The maximum size in bytes for incoming request bodies.
 		2*1024*1024,

--- a/cookie/cookie.go
+++ b/cookie/cookie.go
@@ -123,17 +123,6 @@ var (
 	once sync.Once //nolint:gochecknoglobals
 )
 
-// getAntiReplay fetched any antiReplay data from [http.Request].
-func getAntiReplay(r *http.Request) string {
-	ctx := r.Context()
-	if vCtx := ctx.Value(octx.AntiReplayCtxKey); vCtx != nil {
-		if s, ok := vCtx.(string); ok {
-			return s
-		}
-	}
-	return ""
-}
-
 // SetEncrypted creates a cookie on the HTTP response.
 // The cookie value(but not the name) is encrypted and authenticated using [cry.Enc].
 //
@@ -270,6 +259,17 @@ func Delete(w http.ResponseWriter, name, domain string) {
 		Expires: time.Unix(0, 0),
 	}
 	http.SetCookie(w, c)
+}
+
+// getAntiReplay fetched any antiReplay data from [http.Request].
+func getAntiReplay(r *http.Request) string {
+	ctx := r.Context()
+	if vCtx := ctx.Value(octx.AntiReplayCtxKey); vCtx != nil {
+		if s, ok := vCtx.(string); ok {
+			return s
+		}
+	}
+	return ""
 }
 
 // SetAntiReplay uses antiReplay to try and mitigate against [replay attacks].

--- a/cookie/cookie.go
+++ b/cookie/cookie.go
@@ -288,16 +288,16 @@ func SetAntiReplay(r *http.Request, antiReplay string) *http.Request {
 //
 // [replay attacks]: https://en.wikipedia.org/wiki/Replay_attack
 func UseClientAntiReplay(r *http.Request) *http.Request {
-	fingerprint := finger.Get(
-		// might also be spoofed??
-		r,
-	)
 	ip := clientip.Get(
 		// Note:
 		//   - client IP can be spoofed easily and this could lead to issues with their cookies.
 		//   - also it means that if someone moves from wifi internet to phone internet, their IP changes and cookie/session will be invalid.
 		r,
 	)
+	fingerprint := finger.Get(
+		// might also be spoofed??
+		r,
+	)
 
-	return SetAntiReplay(r, fmt.Sprintf("%s:%s", fingerprint, ip))
+	return SetAntiReplay(r, fmt.Sprintf("%s-%s", ip, fingerprint))
 }

--- a/cookie/cookie.go
+++ b/cookie/cookie.go
@@ -125,16 +125,23 @@ var (
 
 // TODO: should the antiReplay funcs be in the session package?
 
-// TODO:
-func setAntiReplay(r *http.Request, data string) *http.Request {
+// SetAntiReplay uses antiReplay to try and mitigate against [replay attacks].
+// It is not foolproof though.
+//
+// Also see [UseClientAntiReplay]
+//
+// [replay attacks]: https://en.wikipedia.org/wiki/Replay_attack
+func SetAntiReplay(r *http.Request, antiReplay string) *http.Request {
 	ctx := r.Context()
-	ctx = context.WithValue(ctx, octx.AntiReplayCtxKey, data)
+	ctx = context.WithValue(ctx, octx.AntiReplayCtxKey, antiReplay)
 	r = r.WithContext(ctx)
 	return r
 }
 
-// TODO:
-func setClientAntiReplay(r *http.Request) *http.Request {
+// UseClientAntiReplay uses the client IP address and client TLS fingerprint to try and mitigate against [replay attacks].
+//
+// [replay attacks]: https://en.wikipedia.org/wiki/Replay_attack
+func UseClientAntiReplay(r *http.Request) *http.Request {
 	ip := clientip.Get(
 		// Note:
 		//   - client IP can be spoofed easily and this could lead to issues with their cookies.
@@ -146,7 +153,7 @@ func setClientAntiReplay(r *http.Request) *http.Request {
 		r,
 	)
 
-	return setAntiReplay(r, fmt.Sprintf("%s:%s", ip, fingerprint))
+	return SetAntiReplay(r, fmt.Sprintf("%s:%s", ip, fingerprint))
 }
 
 // TODO:

--- a/cookie/cookie.go
+++ b/cookie/cookie.go
@@ -2,7 +2,6 @@
 package cookie
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -12,8 +11,6 @@ import (
 	"time"
 
 	"github.com/komuw/ong/cry"
-	"github.com/komuw/ong/internal/clientip"
-	"github.com/komuw/ong/internal/finger"
 	"github.com/komuw/ong/internal/octx"
 )
 
@@ -123,41 +120,7 @@ var (
 	once sync.Once //nolint:gochecknoglobals
 )
 
-// TODO: should the antiReplay funcs be in the session package?
-
-// SetAntiReplay uses antiReplay to try and mitigate against [replay attacks].
-// It is not foolproof though.
-//
-// Also see [UseClientAntiReplay]
-//
-// [replay attacks]: https://en.wikipedia.org/wiki/Replay_attack
-func SetAntiReplay(r *http.Request, antiReplay string) *http.Request {
-	ctx := r.Context()
-	ctx = context.WithValue(ctx, octx.AntiReplayCtxKey, antiReplay)
-	r = r.WithContext(ctx)
-
-	return r
-}
-
-// UseClientAntiReplay uses the client IP address and client TLS fingerprint to try and mitigate against [replay attacks].
-//
-// [replay attacks]: https://en.wikipedia.org/wiki/Replay_attack
-func UseClientAntiReplay(r *http.Request) *http.Request {
-	ip := clientip.Get(
-		// Note:
-		//   - client IP can be spoofed easily and this could lead to issues with their cookies.
-		//   - also it means that if someone moves from wifi internet to phone internet, their IP changes and cookie/session will be invalid.
-		r,
-	)
-	fingerprint := finger.Get(
-		// might also be spoofed??
-		r,
-	)
-
-	return SetAntiReplay(r, fmt.Sprintf("%s:%s", ip, fingerprint))
-}
-
-// TODO:
+// getAntiReplay fetched any antiReplay data from [http.Request].
 func getAntiReplay(r *http.Request) string {
 	ctx := r.Context()
 	if vCtx := ctx.Value(octx.AntiReplayCtxKey); vCtx != nil {

--- a/cookie/cookie.go
+++ b/cookie/cookie.go
@@ -14,6 +14,7 @@ import (
 	"github.com/komuw/ong/cry"
 	"github.com/komuw/ong/internal/clientip"
 	"github.com/komuw/ong/internal/finger"
+	"github.com/komuw/ong/internal/octx"
 )
 
 const (
@@ -125,15 +126,9 @@ var (
 // TODO: should the antiReplay funcs be in the session package?
 
 // TODO:
-type antiReplayContextKeyType string
-
-// TODO:
-const antiReplayCtxKey = antiReplayContextKeyType("antiReplayContextKeyType")
-
-// TODO:
 func setAntiReplay(r *http.Request, data string) *http.Request {
 	ctx := r.Context()
-	ctx = context.WithValue(ctx, antiReplayCtxKey, data)
+	ctx = context.WithValue(ctx, octx.AntiReplayCtxKey, data)
 	r = r.WithContext(ctx)
 	return r
 }
@@ -157,7 +152,7 @@ func setClientAntiReplay(r *http.Request) *http.Request {
 // TODO:
 func getAntiReplay(r *http.Request) string {
 	ctx := r.Context()
-	if vCtx := ctx.Value(antiReplayCtxKey); vCtx != nil {
+	if vCtx := ctx.Value(octx.AntiReplayCtxKey); vCtx != nil {
 		if s, ok := vCtx.(string); ok {
 			return s
 		}

--- a/cookie/cookie.go
+++ b/cookie/cookie.go
@@ -288,16 +288,16 @@ func SetAntiReplay(r *http.Request, antiReplay string) *http.Request {
 //
 // [replay attacks]: https://en.wikipedia.org/wiki/Replay_attack
 func UseClientAntiReplay(r *http.Request) *http.Request {
+	fingerprint := finger.Get(
+		// might also be spoofed??
+		r,
+	)
 	ip := clientip.Get(
 		// Note:
 		//   - client IP can be spoofed easily and this could lead to issues with their cookies.
 		//   - also it means that if someone moves from wifi internet to phone internet, their IP changes and cookie/session will be invalid.
 		r,
 	)
-	fingerprint := finger.Get(
-		// might also be spoofed??
-		r,
-	)
 
-	return SetAntiReplay(r, fmt.Sprintf("%s:%s", ip, fingerprint))
+	return SetAntiReplay(r, fmt.Sprintf("%s:%s", fingerprint, ip))
 }

--- a/cookie/cookie.go
+++ b/cookie/cookie.go
@@ -135,6 +135,7 @@ func SetAntiReplay(r *http.Request, antiReplay string) *http.Request {
 	ctx := r.Context()
 	ctx = context.WithValue(ctx, octx.AntiReplayCtxKey, antiReplay)
 	r = r.WithContext(ctx)
+
 	return r
 }
 

--- a/cookie/cookie.go
+++ b/cookie/cookie.go
@@ -258,7 +258,7 @@ func GetEncrypted(
 		// This does not completely stop them, but it is better than nothing.
 		incomingAntiReplay := getAntiReplay(r)
 		if antiReplay != incomingAntiReplay {
-			return nil, errors.New("ong/cookie: mismatched AntiReplay value")
+			return nil, errors.New("ong/cookie: mismatched anti replay value")
 		}
 
 		expires, errP := strconv.ParseInt(expiresStr, 10, 64)

--- a/cookie/cookie.go
+++ b/cookie/cookie.go
@@ -273,7 +273,7 @@ func getAntiReplay(r *http.Request) string {
 }
 
 // SetAntiReplay uses antiReplay to try and mitigate against [replay attacks].
-// It is not foolproof though.
+// This mitigation not foolproof.
 //
 // [replay attacks]: https://en.wikipedia.org/wiki/Replay_attack
 func SetAntiReplay(r *http.Request, antiReplay string) *http.Request {

--- a/cookie/cookie_test.go
+++ b/cookie/cookie_test.go
@@ -12,6 +12,8 @@ import (
 	"go.uber.org/goleak"
 )
 
+// TODO: add tests.
+
 func setHandler(name, value, domain string, mAge time.Duration, jsAccess bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		Set(w, name, value, domain, mAge, jsAccess)

--- a/cookie/cookie_test.go
+++ b/cookie/cookie_test.go
@@ -12,8 +12,6 @@ import (
 	"go.uber.org/goleak"
 )
 
-// TODO: add tests.
-
 func setHandler(name, value, domain string, mAge time.Duration, jsAccess bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		Set(w, name, value, domain, mAge, jsAccess)
@@ -185,6 +183,23 @@ func TestCookies(t *testing.T) {
 
 		attest.Zero(t, val)
 		attest.Error(t, err)
+	})
+
+	t.Run("anti-replay", func(t *testing.T) {
+		t.Parallel()
+
+		header := "Anti-Replay"
+		antiReplayFunc := func(r *http.Request) string {
+			return r.Header.Get(header)
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/someUri", nil)
+		headerVal := "some-unique-val-1326"
+		req.Header.Add(header, headerVal)
+		req = SetAntiReplay(req, antiReplayFunc(req))
+
+		res := getAntiReplay(req)
+		attest.Equal(t, res, headerVal)
 	})
 }
 

--- a/internal/octx/octx.go
+++ b/internal/octx/octx.go
@@ -2,8 +2,9 @@
 package octx
 
 type (
-	logContextKeyType  string
-	fingerPrintKeyType string
+	logContextKeyType        string
+	fingerPrintKeyType       string
+	antiReplayContextKeyType string
 )
 
 const (
@@ -13,4 +14,9 @@ const (
 
 	// FingerPrintCtxKey is the name of the context key used to store the TLS fingerprint.
 	FingerPrintCtxKey = fingerPrintKeyType("fingerPrintKeyType")
+
+	// AntiReplayCtxKey is the name of the context key used to store cookie anti [replay attacks] data.
+	//
+	// [replay attacks]: https://en.wikipedia.org/wiki/Replay_attack
+	AntiReplayCtxKey = antiReplayContextKeyType("antiReplayContextKeyType")
 )

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -79,6 +79,7 @@ func allDefaultMiddlewares(
 
 	// session
 	sessionCookieDuration := o.SessionCookieDuration
+	SessionAntiReplyFunc := o.SessionAntiReplyFunc
 
 	// The way the middlewares are layered is:
 	// 1.  trace on outer most since we need to add logID's earliest for use by inner middlewares.
@@ -142,8 +143,7 @@ func allDefaultMiddlewares(
 																string(secretKey),
 																domain,
 																sessionCookieDuration,
-																// TODO: use proper variable.
-																func(r *http.Request) string { return r.RemoteAddr },
+																SessionAntiReplyFunc,
 															),
 															domain,
 														),

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -142,6 +142,8 @@ func allDefaultMiddlewares(
 																string(secretKey),
 																domain,
 																sessionCookieDuration,
+																// TODO: use proper variable.
+																func(r *http.Request) string { return r.RemoteAddr },
 															),
 															domain,
 														),

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -501,6 +501,7 @@ func BenchmarkAllMiddlewares(b *testing.B) {
 		config.DefaultCorsCacheDuration,
 		config.DefaultCsrfCookieDuration,
 		config.DefaultSessionCookieDuration,
+		config.DefaultSessionAntiReplyFunc,
 		20*1024*1024,
 		slog.LevelDebug,
 		1*time.Second,

--- a/middleware/session.go
+++ b/middleware/session.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/komuw/ong/config"
-	"github.com/komuw/ong/cookie"
 	"github.com/komuw/ong/sess"
 )
 
@@ -30,14 +29,9 @@ func session(
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		// 1. Set anti replay data.
-		{
-			antiReplay := antiReplay(r)
-			r = cookie.SetAntiReplay(r, antiReplay)
-		}
-
 		// 2. Read from cookies and check for session cookie.
 		// 3. Get that cookie and save it to r.context
-		r = sess.Initialise(r, secretKey)
+		r = sess.Initialise(r, secretKey, antiReplay(r))
 
 		srw := newSessRW(w, r, domain, secretKey, sessionCookieDuration)
 

--- a/middleware/session.go
+++ b/middleware/session.go
@@ -29,7 +29,7 @@ func session(
 	return func(w http.ResponseWriter, r *http.Request) {
 		// 1. Read from cookies and check for session cookie.
 		// 2. Get that cookie and save it to r.context
-		r = sess.Initialise(r, secretKey)
+		r = sess.Initialise(r, secretKey, "TODO:")
 
 		srw := newSessRW(w, r, domain, secretKey, sessionCookieDuration)
 

--- a/middleware/session_test.go
+++ b/middleware/session_test.go
@@ -269,7 +269,7 @@ func TestSession(t *testing.T) {
 		secretKey := tst.SecretKey()
 		domain := "localhost"
 		key := "bothNames"
-		value := "John Doe"
+		value := "John Doe Jnr"
 		wrappedHandler := session(
 			someSessionHandler(msg, key, value),
 			secretKey,

--- a/middleware/session_test.go
+++ b/middleware/session_test.go
@@ -268,7 +268,7 @@ func TestSession(t *testing.T) {
 		msg := "hello"
 		secretKey := tst.SecretKey()
 		domain := "localhost"
-		key := "name"
+		key := "bothNames"
 		value := "John Doe"
 		wrappedHandler := session(
 			someSessionHandler(msg, key, value),

--- a/middleware/session_test.go
+++ b/middleware/session_test.go
@@ -145,8 +145,8 @@ func TestSession(t *testing.T) {
 		attest.NotZero(t, res.Cookies()[0].Value)
 
 		{
-			req2, err := http.NewRequest(http.MethodGet, ts.URL, nil)
-			attest.Ok(t, err)
+			req2, errN := http.NewRequest(http.MethodGet, ts.URL, nil)
+			attest.Ok(t, errN)
 
 			// very important to do this assignment, since `antiReplayFunc` checks for IP mismatch.
 			req2.Header.Add(header, headerVal)
@@ -157,8 +157,8 @@ func TestSession(t *testing.T) {
 				Value: res.Cookies()[0].Value,
 			})
 
-			c, err := cookie.GetEncrypted(req2, sess.CookieName, secretKey)
-			attest.Ok(t, err)
+			c, errG := cookie.GetEncrypted(req2, sess.CookieName, secretKey)
+			attest.Ok(t, errG)
 			attest.Subsequence(t, c.Value, key)
 			attest.Subsequence(t, c.Value, value)
 		}
@@ -239,8 +239,8 @@ func TestSession(t *testing.T) {
 				Value: res.Cookies()[0].Value,
 			})
 
-			c, err := cookie.GetEncrypted(req2, sess.CookieName, secretKey)
-			attest.Ok(t, err)
+			c, errG := cookie.GetEncrypted(req2, sess.CookieName, secretKey)
+			attest.Ok(t, errG)
 			attest.Subsequence(t, c.Value, key)
 			attest.Subsequence(t, c.Value, value)
 		}
@@ -255,10 +255,10 @@ func TestSession(t *testing.T) {
 				Value: res.Cookies()[0].Value,
 			})
 
-			c, err := cookie.GetEncrypted(req3, sess.CookieName, secretKey)
-			attest.Error(t, err)
+			c, errG := cookie.GetEncrypted(req3, sess.CookieName, secretKey)
+			attest.Error(t, errG)
 			attest.Zero(t, c)
-			attest.Subsequence(t, err.Error(), "mismatched anti replay value")
+			attest.Subsequence(t, errG.Error(), "mismatched anti replay value")
 		}
 	})
 

--- a/middleware/session_test.go
+++ b/middleware/session_test.go
@@ -150,7 +150,7 @@ func TestSession(t *testing.T) {
 
 			// very important to do this assignment, since `antiReplayFunc` checks for IP mismatch.
 			req2.Header.Add(header, headerVal)
-			req2 = cookie.SetAntiReplay(req2, antiReplayFunc(req2))
+			req2 = sess.SetAntiReplay(req2, antiReplayFunc(req2))
 			attest.Ok(t, err)
 			req2.AddCookie(&http.Cookie{
 				Name:  res.Cookies()[0].Name,
@@ -233,7 +233,7 @@ func TestSession(t *testing.T) {
 			req2 := httptest.NewRequest(http.MethodGet, "/hey-uri", nil)
 			// very important to do this assignment, since `antiReplayFunc` checks for IP mismatch.
 			req2.RemoteAddr = ip1
-			req2 = cookie.SetAntiReplay(req2, antiReplayFunc(req2))
+			req2 = sess.SetAntiReplay(req2, antiReplayFunc(req2))
 			req2.AddCookie(&http.Cookie{
 				Name:  res.Cookies()[0].Name,
 				Value: res.Cookies()[0].Value,
@@ -249,7 +249,7 @@ func TestSession(t *testing.T) {
 			req3 := httptest.NewRequest(http.MethodGet, "/hey-uri", nil)
 			ip2 := "148.65.4.3"
 			req3.RemoteAddr = ip2
-			req3 = cookie.SetAntiReplay(req3, antiReplayFunc(req3))
+			req3 = sess.SetAntiReplay(req3, antiReplayFunc(req3))
 			req3.AddCookie(&http.Cookie{
 				Name:  res.Cookies()[0].Name,
 				Value: res.Cookies()[0].Value,

--- a/middleware/session_test.go
+++ b/middleware/session_test.go
@@ -150,7 +150,7 @@ func TestSession(t *testing.T) {
 
 			// very important to do this assignment, since `antiReplayFunc` checks for IP mismatch.
 			req2.Header.Add(header, headerVal)
-			req2 = sess.SetAntiReplay(req2, antiReplayFunc(req2))
+			req2 = cookie.SetAntiReplay(req2, antiReplayFunc(req2))
 			attest.Ok(t, err)
 			req2.AddCookie(&http.Cookie{
 				Name:  res.Cookies()[0].Name,
@@ -233,7 +233,7 @@ func TestSession(t *testing.T) {
 			req2 := httptest.NewRequest(http.MethodGet, "/hey-uri", nil)
 			// very important to do this assignment, since `antiReplayFunc` checks for IP mismatch.
 			req2.RemoteAddr = ip1
-			req2 = sess.SetAntiReplay(req2, antiReplayFunc(req2))
+			req2 = cookie.SetAntiReplay(req2, antiReplayFunc(req2))
 			req2.AddCookie(&http.Cookie{
 				Name:  res.Cookies()[0].Name,
 				Value: res.Cookies()[0].Value,
@@ -249,7 +249,7 @@ func TestSession(t *testing.T) {
 			req3 := httptest.NewRequest(http.MethodGet, "/hey-uri", nil)
 			ip2 := "148.65.4.3"
 			req3.RemoteAddr = ip2
-			req3 = sess.SetAntiReplay(req3, antiReplayFunc(req3))
+			req3 = cookie.SetAntiReplay(req3, antiReplayFunc(req3))
 			req3.AddCookie(&http.Cookie{
 				Name:  res.Cookies()[0].Name,
 				Value: res.Cookies()[0].Value,

--- a/sess/sess.go
+++ b/sess/sess.go
@@ -25,10 +25,15 @@ const (
 )
 
 // Initialise returns a new http.Request (based on r) that has sessions properly setup.
+// If uses antiReplay to try and mitigate against [replay attacks]. It is not foolproof though.
 //
 // You do not need to call this function, if you are also using the ong [github.com/komuw/ong/middleware] middleware.
 // Those middleware do so automatically for you.
-func Initialise(r *http.Request, secretKey string) *http.Request {
+//
+// [replay attacks]: https://en.wikipedia.org/wiki/Replay_attack
+func Initialise(r *http.Request, secretKey, antiReplay string) *http.Request {
+	r = cookie.SetAntiReplay(r, antiReplay)
+
 	ctx := r.Context()
 	var sessVal M // should be per request.
 

--- a/sess/sess.go
+++ b/sess/sess.go
@@ -26,6 +26,7 @@ const (
 
 // Initialise returns a new http.Request (based on r) that has sessions properly setup.
 // If antiReplay is a non-empty string, it is used to try and mitigate against [replay attacks].
+// This mitigation not foolproof.
 //
 // You do not need to call this function, if you are also using the [ong middleware].
 // Those middleware do so automatically for you.

--- a/sess/sess.go
+++ b/sess/sess.go
@@ -25,10 +25,16 @@ const (
 )
 
 // Initialise returns a new http.Request (based on r) that has sessions properly setup.
+// If antiReplay is a non-empty string, it is used to try and mitigate against [replay attacks].
 //
-// You do not need to call this function, if you are also using the ong [github.com/komuw/ong/middleware] middleware.
+// You do not need to call this function, if you are also using the [ong middleware].
 // Those middleware do so automatically for you.
-func Initialise(r *http.Request, secretKey string) *http.Request {
+//
+// [replay attacks]: https://en.wikipedia.org/wiki/Replay_attack
+// [ong middleware]: github.com/komuw/ong/middleware
+func Initialise(r *http.Request, secretKey, antiReplay string) *http.Request {
+	r = cookie.SetAntiReplay(r, antiReplay)
+
 	ctx := r.Context()
 	var sessVal M // should be per request.
 

--- a/sess/sess.go
+++ b/sess/sess.go
@@ -5,15 +5,11 @@ package sess
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"maps"
 	"net/http"
 	"time"
 
 	"github.com/komuw/ong/cookie"
-	"github.com/komuw/ong/internal/clientip"
-	"github.com/komuw/ong/internal/finger"
-	"github.com/komuw/ong/internal/octx"
 )
 
 type (
@@ -37,7 +33,7 @@ const (
 // [replay attacks]: https://en.wikipedia.org/wiki/Replay_attack
 // [ong middleware]: github.com/komuw/ong/middleware
 func Initialise(r *http.Request, secretKey, antiReplay string) *http.Request {
-	r = SetAntiReplay(r, antiReplay)
+	r = cookie.SetAntiReplay(r, antiReplay)
 
 	ctx := r.Context()
 	var sessVal M // should be per request.
@@ -148,34 +144,4 @@ func Save(
 		mAge,
 		secretKey,
 	)
-}
-
-// SetAntiReplay uses antiReplay to try and mitigate against [replay attacks].
-// It is not foolproof though.
-//
-// [replay attacks]: https://en.wikipedia.org/wiki/Replay_attack
-func SetAntiReplay(r *http.Request, antiReplay string) *http.Request {
-	ctx := r.Context()
-	ctx = context.WithValue(ctx, octx.AntiReplayCtxKey, antiReplay)
-	r = r.WithContext(ctx)
-
-	return r
-}
-
-// UseClientAntiReplay uses the client IP address and client TLS fingerprint to try and mitigate against [replay attacks].
-//
-// [replay attacks]: https://en.wikipedia.org/wiki/Replay_attack
-func UseClientAntiReplay(r *http.Request) *http.Request {
-	ip := clientip.Get(
-		// Note:
-		//   - client IP can be spoofed easily and this could lead to issues with their cookies.
-		//   - also it means that if someone moves from wifi internet to phone internet, their IP changes and cookie/session will be invalid.
-		r,
-	)
-	fingerprint := finger.Get(
-		// might also be spoofed??
-		r,
-	)
-
-	return SetAntiReplay(r, fmt.Sprintf("%s:%s", ip, fingerprint))
 }

--- a/sess/sess.go
+++ b/sess/sess.go
@@ -25,15 +25,10 @@ const (
 )
 
 // Initialise returns a new http.Request (based on r) that has sessions properly setup.
-// If uses antiReplay to try and mitigate against [replay attacks]. It is not foolproof though.
 //
 // You do not need to call this function, if you are also using the ong [github.com/komuw/ong/middleware] middleware.
 // Those middleware do so automatically for you.
-//
-// [replay attacks]: https://en.wikipedia.org/wiki/Replay_attack
-func Initialise(r *http.Request, secretKey, antiReplay string) *http.Request {
-	r = cookie.SetAntiReplay(r, antiReplay)
-
+func Initialise(r *http.Request, secretKey string) *http.Request {
 	ctx := r.Context()
 	var sessVal M // should be per request.
 

--- a/sess/sess_test.go
+++ b/sess/sess_test.go
@@ -24,7 +24,7 @@ func TestSess(t *testing.T) {
 
 		req, err := http.NewRequest(http.MethodGet, "/someUri", nil)
 		attest.Ok(t, err)
-		req = Initialise(req, tst.SecretKey(), "")
+		req = Initialise(req, tst.SecretKey())
 
 		res := req.Context().Value(ctxKey).(map[string]string)
 		attest.Equal(t, res, map[string]string{})
@@ -38,7 +38,7 @@ func TestSess(t *testing.T) {
 
 		req, err := http.NewRequest(http.MethodGet, "/someUri", nil)
 		attest.Ok(t, err)
-		req = Initialise(req, tst.SecretKey(), "")
+		req = Initialise(req, tst.SecretKey())
 
 		Set(req, k, v)
 		res := req.Context().Value(ctxKey).(map[string]string)
@@ -52,7 +52,7 @@ func TestSess(t *testing.T) {
 
 		req, err := http.NewRequest(http.MethodGet, "/someUri", nil)
 		attest.Ok(t, err)
-		req = Initialise(req, tst.SecretKey(), "")
+		req = Initialise(req, tst.SecretKey())
 
 		SetM(req, m)
 		res := req.Context().Value(ctxKey).(map[string]string)
@@ -66,7 +66,7 @@ func TestSess(t *testing.T) {
 		v := "John Keypoole"
 		req, err := http.NewRequest(http.MethodGet, "/someUri", nil)
 		attest.Ok(t, err)
-		req = Initialise(req, tst.SecretKey(), "")
+		req = Initialise(req, tst.SecretKey())
 
 		{
 			one := Get(req, k)
@@ -89,7 +89,7 @@ func TestSess(t *testing.T) {
 		m := M{"name": "John Doe", "age": "99"}
 		req, err := http.NewRequest(http.MethodGet, "/someUri", nil)
 		attest.Ok(t, err)
-		req = Initialise(req, tst.SecretKey(), "")
+		req = Initialise(req, tst.SecretKey())
 
 		{
 			one := GetM(req)
@@ -122,7 +122,7 @@ func TestSess(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "/someUri", nil)
 		attest.Ok(t, err)
 		rec := httptest.NewRecorder()
-		req = Initialise(req, tst.SecretKey(), "")
+		req = Initialise(req, tst.SecretKey())
 
 		{
 			SetM(req, m)

--- a/sess/sess_test.go
+++ b/sess/sess_test.go
@@ -24,7 +24,7 @@ func TestSess(t *testing.T) {
 
 		req, err := http.NewRequest(http.MethodGet, "/someUri", nil)
 		attest.Ok(t, err)
-		req = Initialise(req, tst.SecretKey())
+		req = Initialise(req, tst.SecretKey(), "")
 
 		res := req.Context().Value(ctxKey).(map[string]string)
 		attest.Equal(t, res, map[string]string{})
@@ -38,7 +38,7 @@ func TestSess(t *testing.T) {
 
 		req, err := http.NewRequest(http.MethodGet, "/someUri", nil)
 		attest.Ok(t, err)
-		req = Initialise(req, tst.SecretKey())
+		req = Initialise(req, tst.SecretKey(), "")
 
 		Set(req, k, v)
 		res := req.Context().Value(ctxKey).(map[string]string)
@@ -52,7 +52,7 @@ func TestSess(t *testing.T) {
 
 		req, err := http.NewRequest(http.MethodGet, "/someUri", nil)
 		attest.Ok(t, err)
-		req = Initialise(req, tst.SecretKey())
+		req = Initialise(req, tst.SecretKey(), "")
 
 		SetM(req, m)
 		res := req.Context().Value(ctxKey).(map[string]string)
@@ -66,7 +66,7 @@ func TestSess(t *testing.T) {
 		v := "John Keypoole"
 		req, err := http.NewRequest(http.MethodGet, "/someUri", nil)
 		attest.Ok(t, err)
-		req = Initialise(req, tst.SecretKey())
+		req = Initialise(req, tst.SecretKey(), "")
 
 		{
 			one := Get(req, k)
@@ -89,7 +89,7 @@ func TestSess(t *testing.T) {
 		m := M{"name": "John Doe", "age": "99"}
 		req, err := http.NewRequest(http.MethodGet, "/someUri", nil)
 		attest.Ok(t, err)
-		req = Initialise(req, tst.SecretKey())
+		req = Initialise(req, tst.SecretKey(), "")
 
 		{
 			one := GetM(req)
@@ -122,7 +122,7 @@ func TestSess(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "/someUri", nil)
 		attest.Ok(t, err)
 		rec := httptest.NewRecorder()
-		req = Initialise(req, tst.SecretKey())
+		req = Initialise(req, tst.SecretKey(), "")
 
 		{
 			SetM(req, m)


### PR DESCRIPTION
- Previously when validating encrypted cookies, we would compare the IP address(and TLS fingerprint) in the coming request to the one in the cookie.    
  This meant that if someone moves from wifi internet to phone internet(as an example), their IP changes and thus their cookie/session would be invalid.
- Since the feature is useful in trying to mitigate against replay attacks(see: https://github.com/komuw/ong/issues/144), we instead introduce functionality that would allow users of `ong` to set whatever value they want as their anti replay data.  
  So someone could set the IP + geo-location of the request as the anti replay data, and if either of those change; the cookies are invalid.

- Fixes: https://github.com/komuw/ong/issues/365