### PR TITLE
Do not loadshed based on latency from pprof endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 1
     strategy:
       matrix:
-        go-version: ['>=1.21.1']
+        go-version: ['>1.21.1']
         platform: [ubuntu-22.04]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -68,7 +68,7 @@ jobs:
     timeout-minutes: 7
     strategy:
       matrix:
-        go-version: ['>=1.21.1']
+        go-version: ['>1.21.1']
         platform: [ubuntu-22.04]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -102,7 +102,7 @@ jobs:
     timeout-minutes: 8
     strategy:
       matrix:
-        go-version: ['>=1.21.1']
+        go-version: ['>1.21.1']
         platform: [ubuntu-22.04]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -208,7 +208,7 @@ jobs:
     timeout-minutes: 3
     strategy:
       matrix:
-        go-version: ['>=1.21.1']
+        go-version: ['>1.21.1']
         platform: [ubuntu-22.04]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -265,7 +265,7 @@ jobs:
   #   timeout-minutes: 2
   #   strategy:
   #     matrix:
-  #       go-version: ['>=1.21.1']
+  #       go-version: ['>1.21.1']
   #       platform: [ubuntu-22.04]
   #   runs-on: ${{ matrix.platform }}
   #   steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Most recent version is listed first.  
 
 
+# v0.0.85
+- Do not loadshed based on latency from pprof endpoints: https://github.com/komuw/ong/pull/392
+
 # v0.0.84
 - ong/cookies: Fix name of antiReplay mechanism that uses client fingerprint: https://github.com/komuw/ong/pull/390
 


### PR DESCRIPTION
- Ignore pprof endpoints when calculating latencies that inform load shedding decision.