### PR TITLE
issues/421: Use the right token when verifying challenge token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Most recent version is listed first.  
 
 
+# v0.0.96
+- ong/acme: verify the requested acme challenge token: https://github.com/komuw/ong/pull/440
+  This is a bug fix for v0.0.95
+
 # v0.0.95
 - ong/acme: verify the requested acme challenge token: https://github.com/komuw/ong/pull/439
 

--- a/internal/acme/acme_test.go
+++ b/internal/acme/acme_test.go
@@ -359,20 +359,10 @@ func TestAcmeHandler(t *testing.T) {
 			attest.True(t, certIsValid(cert))
 		}
 
-		token := ""
-		{
-			diskCacheDir, err := diskCachedir()
-			attest.Ok(t, err)
-			tokenPath := filepath.Join(diskCacheDir, domain, tokenFileName)
-			tok, err := os.ReadFile(tokenPath)
-			attest.Ok(t, err)
-			token = string(tok)
-		}
-
 		msg := "hello"
 		wrappedHandler := Handler(someAcmeAppHandler(msg))
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", challengeURI, token), nil)
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", challengeURI, acmeTestToken), nil)
 		req.Host = domain
 		wrappedHandler.ServeHTTP(rec, req)
 

--- a/internal/acme/acme_test.go
+++ b/internal/acme/acme_test.go
@@ -616,11 +616,17 @@ func BenchmarkHandler(b *testing.B) {
 		diskCacheDir, err := diskCachedir()
 		attest.Ok(b, err)
 
-		certPath := filepath.Join(diskCacheDir, domain, tokenFileName)
+		tokenPath := filepath.Join(diskCacheDir, domain, tokenFileName)
 		err = os.MkdirAll(filepath.Join(diskCacheDir, domain), 0o755)
 		attest.Ok(b, err)
 
-		err = os.WriteFile(certPath, []byte(token), 0o600)
+		accountKeyPath := filepath.Join(diskCacheDir, accountKeyFileName)
+		accountPrivKey, err := getEcdsaPrivKey(accountKeyPath)
+		attest.Ok(b, err)
+		tokenToWrite, err := jWKThumbprint(accountPrivKey.PublicKey, token)
+		attest.Ok(b, err)
+
+		err = os.WriteFile(tokenPath, []byte(tokenToWrite), 0o600)
 		attest.Ok(b, err)
 	}
 

--- a/internal/acme/acme_test.go
+++ b/internal/acme/acme_test.go
@@ -437,11 +437,11 @@ func TestAcmeHandler(t *testing.T) {
 		wrappedHandler := Handler(someAcmeAppHandler(msg))
 		token := "myToken"
 
-		setCerts := func(domain string) (certPath, tokenToWrite string) {
+		setCerts := func(domain string) (tokenPath, tokenToWrite string) {
 			diskCacheDir, err := diskCachedir()
 			attest.Ok(t, err)
 
-			certPath = filepath.Join(diskCacheDir, domain, tokenFileName)
+			tokenPath = filepath.Join(diskCacheDir, domain, tokenFileName)
 			err = os.MkdirAll(filepath.Join(diskCacheDir, domain), 0o755)
 			attest.Ok(t, err)
 
@@ -451,7 +451,7 @@ func TestAcmeHandler(t *testing.T) {
 			tokenToWrite, err = jWKThumbprint(accountPrivKey.PublicKey, token)
 			attest.Ok(t, err)
 
-			return certPath, tokenToWrite
+			return tokenPath, tokenToWrite
 		}
 
 		tests := []struct {
@@ -465,8 +465,8 @@ func TestAcmeHandler(t *testing.T) {
 				req: func() *http.Request {
 					domain := getDomain()
 					{
-						certPath, tokenToWrite := setCerts(domain)
-						err := os.WriteFile(certPath, []byte(tokenToWrite), 0o600)
+						tokenPath, tokenToWrite := setCerts(domain)
+						err := os.WriteFile(tokenPath, []byte(tokenToWrite), 0o600)
 						attest.Ok(t, err)
 					}
 
@@ -505,8 +505,8 @@ func TestAcmeHandler(t *testing.T) {
 				req: func() *http.Request {
 					domain := "2023.example.com"
 					{
-						certPath, tokenToWrite := setCerts(domain)
-						err := os.WriteFile(certPath, []byte(tokenToWrite), 0o600)
+						tokenPath, tokenToWrite := setCerts(domain)
+						err := os.WriteFile(tokenPath, []byte(tokenToWrite), 0o600)
 						attest.Ok(t, err)
 					}
 
@@ -522,8 +522,8 @@ func TestAcmeHandler(t *testing.T) {
 				req: func() *http.Request {
 					domain := "example.com"
 					{
-						certPath, tokenToWrite := setCerts(domain)
-						err := os.WriteFile(certPath, []byte(tokenToWrite), 0o600)
+						tokenPath, tokenToWrite := setCerts(domain)
+						err := os.WriteFile(tokenPath, []byte(tokenToWrite), 0o600)
 						attest.Ok(t, err)
 					}
 
@@ -550,8 +550,8 @@ func TestAcmeHandler(t *testing.T) {
 				req: func() *http.Request {
 					domain := getDomain()
 					{
-						certPath, tokenToWrite := setCerts(domain)
-						err := os.WriteFile(certPath, []byte(tokenToWrite), 0o600)
+						tokenPath, tokenToWrite := setCerts(domain)
+						err := os.WriteFile(tokenPath, []byte(tokenToWrite), 0o600)
 						attest.Ok(t, err)
 					}
 

--- a/internal/acme/acme_test.go
+++ b/internal/acme/acme_test.go
@@ -437,6 +437,23 @@ func TestAcmeHandler(t *testing.T) {
 		wrappedHandler := Handler(someAcmeAppHandler(msg))
 		token := "myToken"
 
+		setCerts := func(domain string) (certPath, tokenToWrite string) {
+			diskCacheDir, err := diskCachedir()
+			attest.Ok(t, err)
+
+			certPath = filepath.Join(diskCacheDir, domain, tokenFileName)
+			err = os.MkdirAll(filepath.Join(diskCacheDir, domain), 0o755)
+			attest.Ok(t, err)
+
+			accountKeyPath := filepath.Join(diskCacheDir, accountKeyFileName)
+			accountPrivKey, err := getEcdsaPrivKey(accountKeyPath)
+			attest.Ok(t, err)
+			tokenToWrite, err = jWKThumbprint(accountPrivKey.PublicKey, token)
+			attest.Ok(t, err)
+
+			return certPath, tokenToWrite
+		}
+
 		tests := []struct {
 			name string
 			req  func() *http.Request
@@ -448,14 +465,8 @@ func TestAcmeHandler(t *testing.T) {
 				req: func() *http.Request {
 					domain := getDomain()
 					{
-						diskCacheDir, err := diskCachedir()
-						attest.Ok(t, err)
-
-						certPath := filepath.Join(diskCacheDir, domain, tokenFileName)
-						err = os.MkdirAll(filepath.Join(diskCacheDir, domain), 0o755)
-						attest.Ok(t, err)
-
-						err = os.WriteFile(certPath, []byte(token), 0o600)
+						certPath, tokenToWrite := setCerts(domain)
+						err := os.WriteFile(certPath, []byte(tokenToWrite), 0o600)
 						attest.Ok(t, err)
 					}
 
@@ -494,14 +505,8 @@ func TestAcmeHandler(t *testing.T) {
 				req: func() *http.Request {
 					domain := "2023.example.com"
 					{
-						diskCacheDir, err := diskCachedir()
-						attest.Ok(t, err)
-
-						certPath := filepath.Join(diskCacheDir, domain, tokenFileName)
-						err = os.MkdirAll(filepath.Join(diskCacheDir, domain), 0o755)
-						attest.Ok(t, err)
-
-						err = os.WriteFile(certPath, []byte(token), 0o600)
+						certPath, tokenToWrite := setCerts(domain)
+						err := os.WriteFile(certPath, []byte(tokenToWrite), 0o600)
 						attest.Ok(t, err)
 					}
 
@@ -517,14 +522,8 @@ func TestAcmeHandler(t *testing.T) {
 				req: func() *http.Request {
 					domain := "example.com"
 					{
-						diskCacheDir, err := diskCachedir()
-						attest.Ok(t, err)
-
-						certPath := filepath.Join(diskCacheDir, domain, tokenFileName)
-						err = os.MkdirAll(filepath.Join(diskCacheDir, domain), 0o755)
-						attest.Ok(t, err)
-
-						err = os.WriteFile(certPath, []byte(token), 0o600)
+						certPath, tokenToWrite := setCerts(domain)
+						err := os.WriteFile(certPath, []byte(tokenToWrite), 0o600)
 						attest.Ok(t, err)
 					}
 
@@ -551,14 +550,8 @@ func TestAcmeHandler(t *testing.T) {
 				req: func() *http.Request {
 					domain := getDomain()
 					{
-						diskCacheDir, err := diskCachedir()
-						attest.Ok(t, err)
-
-						certPath := filepath.Join(diskCacheDir, domain, tokenFileName)
-						err = os.MkdirAll(filepath.Join(diskCacheDir, domain), 0o755)
-						attest.Ok(t, err)
-
-						err = os.WriteFile(certPath, []byte(token), 0o600)
+						certPath, tokenToWrite := setCerts(domain)
+						err := os.WriteFile(certPath, []byte(tokenToWrite), 0o600)
 						attest.Ok(t, err)
 					}
 

--- a/internal/acme/client_test.go
+++ b/internal/acme/client_test.go
@@ -20,6 +20,8 @@ import (
 	"go.akshayshah.org/attest"
 )
 
+const acmeTestToken = "random-unique-token-EuKDOWlre4"
+
 // someAcmeServerHandler mimics an ACME server.
 func someAcmeServerHandler(t *testing.T, domain string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -94,14 +96,14 @@ func someAcmeServerHandler(t *testing.T, domain string) http.HandlerFunc {
 						Type:   "http-01",
 						Url:    fmt.Sprintf("http://%s/acme/chall-v3/7052305704/iSRkIw", r.Host),
 						Status: "pending",
-						Token:  "random-unique-token-EuKDOWlre4",
+						Token:  acmeTestToken,
 					},
 				},
 				EffectiveChallenge: challenge{
 					Type:   "http-01",
 					Url:    fmt.Sprintf("http://%s/acme/chall-v3/7052305704/iSRkIw", r.Host),
 					Status: "pending",
-					Token:  "random-unique-token-EuKDOWlre4",
+					Token:  acmeTestToken,
 				},
 			}
 
@@ -117,7 +119,7 @@ func someAcmeServerHandler(t *testing.T, domain string) http.HandlerFunc {
 				Type:   "http-01",
 				Url:    fmt.Sprintf("http://%s/acme/chall-v3/7052305704/iSRkIw", r.Host),
 				Status: "pending",
-				Token:  "random-unique-token-EuKDOWlre4",
+				Token:  acmeTestToken,
 			}
 
 			w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
- Bugfix: Use the right token when verifying challenge token.
  This is take II of https://github.com/komuw/ong/pull/439. In that PR we had made it so that when ACME wants to verify a challenge, we would respond with 404 if the token differs with what we have on file. The problem is that in that PR we were assuming that the token on file has same format as the one ACME calls us with. That is not the case and this PR attempts to fix that.
- Fixes: https://github.com/komuw/ong/issues/421