### PR TITLE
issues/447: Disable reload protector middleware

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -137,16 +137,17 @@ func allDefaultMiddlewares(
 											securityHeaders(
 												cors(
 													csrf(
-														reloadProtector(
-															session(
-																wrappedHandler,
-																string(secretKey),
-																domain,
-																sessionCookieDuration,
-																SessionAntiReplyFunc,
-															),
+														// TODO: re-enable after https://github.com/komuw/ong/issues/447 is fixed.
+														// reloadProtector(
+														session(
+															wrappedHandler,
+															string(secretKey),
 															domain,
+															sessionCookieDuration,
+															SessionAntiReplyFunc,
 														),
+														// 	domain,
+														// ),
 														string(secretKey),
 														domain,
 														csrfTokenDuration,


### PR DESCRIPTION
That middleware is not working as intended. This PR mitigates until we can implement a proper fix.

- Updates: https://github.com/komuw/ong/issues/447
- https://en.wikipedia.org/wiki/Post/Redirect/Get