### PR TITLE
issues/451: errors; retain stack traces when errors are wrapped with fmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Most recent version is listed first.  
 
 
+# v0.0.99
+- ong/errors: errors; retain stack traces when errors are wrapped with fmt: https://github.com/komuw/ong/pull/452
+
 # v0.0.98
 - ong/errors: add equivalent functions from standard library: https://github.com/komuw/ong/pull/449
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -62,15 +62,8 @@ func Dwrap(errp *error) {
 }
 
 func wrap(err error, skip int) error {
-	// c, ok := err.(*stackError)
-	// fmt.Println("c, ok: ", c, ok, Is(err, &stackError{}))
-	// if ok {
-	// 	return c
-	// }
-
 	if Is(err, &stackError{}) {
 		return err
-		// return Unwrap(err)
 	}
 
 	// limit stack size to 64 call depth.

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -28,6 +28,12 @@ func (e *stackError) Unwrap() error {
 	return e.err
 }
 
+// Is reports whether target is a stackError
+func (e *stackError) Is(target error) bool {
+	_, ok := target.(*stackError)
+	return ok
+}
+
 // New returns an error with the supplied message.
 // It also records the stack trace at the point it was called.
 //
@@ -54,10 +60,16 @@ func Dwrap(errp *error) {
 	}
 }
 
-func wrap(err error, skip int) *stackError {
-	c, ok := err.(*stackError)
-	if ok {
-		return c
+func wrap(err error, skip int) error {
+	// c, ok := err.(*stackError)
+	// fmt.Println("c, ok: ", c, ok, Is(err, &stackError{}))
+	// if ok {
+	// 	return c
+	// }
+
+	if Is(err, &stackError{}) {
+		return err
+		// return Unwrap(err)
 	}
 
 	// limit stack size to 64 call depth.
@@ -109,9 +121,6 @@ func (e *stackError) Format(f fmt.State, verb rune) {
 // StackTrace returns the stack trace contained in err, if any, else an empty string.
 func StackTrace(err error) string {
 	if sterr, ok := err.(*stackError); ok {
-		return sterr.getStackTrace()
-	}
-	if sterr, ok := err.(*joinError); ok {
 		return sterr.getStackTrace()
 	}
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -11,7 +11,8 @@ import (
 
 // Some of the code here is inspired(or taken from) by:
 //   (a) https://github.com/golang/pkgsite whose license(BSD 3-Clause "New") can be found here: https://github.com/golang/pkgsite/blob/24f94ffc546bde6aae0552efa6a940041d9d28e1/LICENSE
-//   (b) https://www.komu.engineer/blogs/08/golang-stacktrace
+//   (b) https://gitlab.com/tozd/go/errors whose license(Apache 2.0) can be found here: https://gitlab.com/tozd/go/errors/-/blob/v0.8.1/LICENSE
+//   (c) https://www.komu.engineer/blogs/08/golang-stacktrace
 
 // stackError is an implementation of error that adds stack trace support and error wrapping.
 type stackError struct {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -209,7 +209,6 @@ func TestStackError(t *testing.T) {
 
 		err := f()
 		extendedFormatting := fmt.Sprintf("%+v", err)
-		fmt.Println("extendedFormatting: ", extendedFormatting)
 
 		attest.True(t, stdErrors.Is(err, &stackError{}))
 		attest.Equal(t, err.Error(), "fmting: hey")

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -193,4 +193,25 @@ func TestStackError(t *testing.T) {
 
 		_ = wrap(err, 2) // This is here to quiet golangci-lint which complains that wrap is always called with an argument of 3.
 	})
+
+	t.Run("multiple wrapping preserves traces", func(t *testing.T) {
+		t.Parallel()
+
+		f := func() (err error) {
+			defer Dwrap(&err)
+
+			e1 := New("hey")
+			e2 := Wrap(e1)
+			e3 := Errorf("fmting: %w", e2)
+
+			return e3
+		}
+
+		err := f()
+		extendedFormatting := fmt.Sprintf("%+v", err)
+		fmt.Println("extendedFormatting: ", extendedFormatting)
+
+		attest.True(t, stdErrors.Is(err, &stackError{}))
+		attest.Equal(t, err.Error(), "fmting: hey")
+	})
 }

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -213,5 +213,11 @@ func TestStackError(t *testing.T) {
 
 		attest.True(t, stdErrors.Is(err, &stackError{}))
 		attest.Equal(t, err.Error(), "fmting: hey")
+		for _, v := range []string{
+			"ong/errors/errors_test.go:203",
+			"ong/errors/errors_test.go:210",
+		} {
+			attest.Subsequence(t, extendedFormatting, v, attest.Sprintf("\n\t%s: not found in extendedFormatting: %s", v, extendedFormatting))
+		}
 	})
 }

--- a/errors/join.go
+++ b/errors/join.go
@@ -33,7 +33,8 @@ func Join(errs ...error) error {
 			ef := wrap(err, 3)
 			e.errs = append(e.errs, ef)
 			if e.stackError == nil {
-				e.stackError = ef.(*stackError) // ef is guaranteed to be a stackError since it comes from wrap()
+				eff, _ := ef.(*stackError) // ef is guaranteed to be a stackError since it comes from wrap()
+				e.stackError = eff
 			}
 		}
 	}

--- a/errors/join.go
+++ b/errors/join.go
@@ -33,7 +33,7 @@ func Join(errs ...error) error {
 			ef := wrap(err, 3)
 			e.errs = append(e.errs, ef)
 			if e.stackError == nil {
-				e.stackError = ef
+				e.stackError = ef.(*stackError) // ef is guaranteed to be a stackError
 			}
 		}
 	}

--- a/errors/join.go
+++ b/errors/join.go
@@ -14,7 +14,7 @@ package errors
 //
 // It only returns the stack trace of the first error. Unwrap also only returns the first error.
 //
-// Note that this function is equivalent to the one in standard library only in spirit.
+// Note that this function is equivalent to the one in standard library mainly in spirit.
 // This is not a direct replacement of the standard library one.
 func Join(errs ...error) error {
 	n := 0
@@ -33,7 +33,7 @@ func Join(errs ...error) error {
 			ef := wrap(err, 3)
 			e.errs = append(e.errs, ef)
 			if e.stackError == nil {
-				e.stackError = ef.(*stackError) // ef is guaranteed to be a stackError
+				e.stackError = ef.(*stackError) // ef is guaranteed to be a stackError since it comes from wrap()
 			}
 		}
 	}

--- a/errors/stdlib.go
+++ b/errors/stdlib.go
@@ -31,9 +31,11 @@ func Errorf(format string, a ...any) error {
 		return err
 	case interface{ Unwrap() error }:
 		ef := wrap(u.Unwrap(), 3)
+		eff, _ := ef.(*stackError) // ef is guaranteed to be a stackError since it comes from wrap()
+
 		return &joinError{
 			errs:       []error{err},
-			stackError: ef.(*stackError), // ef is guaranteed to be a stackError since it comes from wrap()
+			stackError: eff,
 		}
 	}
 }

--- a/errors/stdlib.go
+++ b/errors/stdlib.go
@@ -20,7 +20,19 @@ func Unwrap(err error) error {
 	return stdErrors.Unwrap(err)
 }
 
-// Errorf is a pass through to the same func from the standard library fmt package.
+// Errorf is equivalent to the one in standard library mainly in spirit.
 func Errorf(format string, a ...any) error {
-	return fmt.Errorf(format, a...)
+	err := fmt.Errorf(format, a...)
+
+	switch u := err.(type) {
+	default:
+		// todo: handle this somehow
+		return err
+	case interface{ Unwrap() error }:
+		ef := wrap(u.Unwrap(), 3)
+		return &joinError{
+			errs:       []error{err},
+			stackError: ef.(*stackError), // ef is guaranteed to be a stackError since it comes from wrap()
+		}
+	}
 }

--- a/errors/stdlib.go
+++ b/errors/stdlib.go
@@ -24,6 +24,7 @@ func Unwrap(err error) error {
 func Errorf(format string, a ...any) error {
 	err := fmt.Errorf(format, a...)
 
+	// see: https://gitlab.com/tozd/go/errors/-/blob/v0.8.1/errors.go#L324
 	switch u := err.(type) {
 	default:
 		// todo: handle this somehow


### PR DESCRIPTION
- When errors would get passed to `fmt.Errorf`, they would loose their traces.
  This is an issue even with other third party error packages, see linked issue for examples.
  Note; you have to use `errors.Errof` instea of `fmt.Errorf`
- Fixes: https://github.com/komuw/ong/issues/451