### PR TITLE
issues/456: basicAuth; do not show hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Most recent version is listed first.  
 
 
+# v0.1.1
+- ong/middleware: do not show hint: https://github.com/komuw/ong/pull/457 
+
 # v0.1.0
 - ong/errors: handle stacktraces for more error types: https://github.com/komuw/ong/pull/455
 

--- a/example/main.go
+++ b/example/main.go
@@ -27,7 +27,7 @@ func main() {
 		mux.NewRoute(
 			"staticAssets/:file",
 			mux.MethodAll,
-			middleware.BasicAuth(api.handleFileServer(), "user", "some-long-1passwd", "passwd used when registering"),
+			middleware.BasicAuth(api.handleFileServer(), "user", "some-long-1passwd"),
 		),
 		mux.NewRoute(
 			"check/:age/",

--- a/internal/mx/mx_test.go
+++ b/internal/mx/mx_test.go
@@ -60,7 +60,7 @@ func TestNewRoute(t *testing.T) {
 	_, errA := NewRoute(
 		"/api",
 		MethodGet,
-		middleware.BasicAuth(someMuxHandler("msg"), "some-user", "some-very-very-h1rd-passwd", "hey"),
+		middleware.BasicAuth(someMuxHandler("msg"), "some-user", "some-very-very-h1rd-passwd"),
 	)
 	attest.Ok(t, errA)
 

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -8,13 +8,13 @@ import (
 )
 
 // BasicAuth is a middleware that protects wrappedHandler using basic authentication.
-func BasicAuth(wrappedHandler http.Handler, user, passwd, hint string) http.HandlerFunc {
+func BasicAuth(wrappedHandler http.Handler, user, passwd string) http.HandlerFunc {
 	if err := key.IsSecure(passwd); err != nil {
 		panic(err)
 	}
 
 	// See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate
-	realm := `enter username and password: ` + hint
+	realm := `enter username and password`
 	e := func(w http.ResponseWriter) {
 		errMsg := `Basic realm=` + realm
 		w.Header().Set("WWW-Authenticate", errMsg)

--- a/middleware/auth_test.go
+++ b/middleware/auth_test.go
@@ -24,7 +24,7 @@ func TestBasicAuth(t *testing.T) {
 	{
 		// small passwd panics.
 		attest.Panics(t, func() {
-			BasicAuth(protectedHandler("hello"), "user", strings.Repeat("a", 8), "")
+			BasicAuth(protectedHandler("hello"), "user", strings.Repeat("a", 8))
 		},
 		)
 	}
@@ -32,7 +32,7 @@ func TestBasicAuth(t *testing.T) {
 	msg := "hello"
 	user := "some-user"
 	passwd := "some-long-p1sswd"
-	wrappedHandler := BasicAuth(protectedHandler(msg), user, passwd, "")
+	wrappedHandler := BasicAuth(protectedHandler(msg), user, passwd)
 
 	tests := []struct {
 		name     string
@@ -90,7 +90,7 @@ func TestBasicAuth(t *testing.T) {
 
 		// for this concurrency test, we have to re-use the same newWrappedHandler
 		// so that state is shared and thus we can see if there is any state which is not handled correctly.
-		newWrappedHandler := BasicAuth(protectedHandler(msg), user, passwd, "")
+		newWrappedHandler := BasicAuth(protectedHandler(msg), user, passwd)
 
 		runhandler := func() {
 			rec := httptest.NewRecorder()

--- a/server/server.go
+++ b/server/server.go
@@ -71,7 +71,6 @@ func Run(h http.Handler, o config.Opts) error {
 							profHandler,
 							string(o.SecretKey),
 							string(o.SecretKey),
-							"Use config.Opts.SecretKey",
 						),
 					),
 				); err != nil {
@@ -86,7 +85,6 @@ func Run(h http.Handler, o config.Opts) error {
 							profHandler,
 							string(o.SecretKey),
 							string(o.SecretKey),
-							"Use config.Opts.SecretKey",
 						),
 					),
 				); err != nil {


### PR DESCRIPTION
- This was failing in mobile browsers. They were unable to show the username/password popup.
  I suspect that those clients only expect a header of the form `www-authenticate: Basic realm=realmStr`. 
  Where `realmStr` is a string with no special characters. The docs say that `realmStr` is any string whose character set is `us-ascii`. The `:` colon symbol is part of us-ascii(number 58). So I don't know why it would cause mobile clients to fail.
- Fixes: https://github.com/komuw/ong/issues/456
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate#realm