### PR TITLE
Replace scrypt with argon2id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,9 @@
 Most recent version is listed first.  
 
 
-# v0.1.8
-- ong/cry: Replace scrypt with argon2id: https://github.com/komuw/ong/pull/471
-
 # v0.1.7
 - Update go version; https://github.com/komuw/ong/pull/469
+- ong/cry: Replace scrypt with argon2id: https://github.com/komuw/ong/pull/471
 
 # v0.1.6
 - Bump versions of dependencies used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Most recent version is listed first.  
 
 
+# v0.1.8
+- ong/cry: Replace scrypt with argon2id: https://github.com/komuw/ong/pull/471
+
 # v0.1.7
 - Update go version; https://github.com/komuw/ong/pull/469
 

--- a/cry/enc.go
+++ b/cry/enc.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/komuw/ong/internal/key"
 
-	"golang.org/x/crypto/argon2"
 	"golang.org/x/crypto/chacha20poly1305"
 )
 
@@ -134,7 +133,7 @@ func (e Enc) Decrypt(encryptedMsg []byte) (decryptedMsg []byte, err error) {
 	if !slices.Equal(salt, e.salt) {
 		// The encryptedMsg was encrypted using a different salt.
 		// So, we need to get the derived key for that salt and use it for decryption.
-		derivedKey := argon2.IDKey(e.key, salt, time, memory, threads, keyLen)
+		derivedKey := deriveKey(e.key, salt)
 
 		aead, err = chacha20poly1305.NewX(derivedKey)
 		if err != nil {

--- a/cry/enc.go
+++ b/cry/enc.go
@@ -41,9 +41,9 @@ var (
 	//
 	// The values recommended are:
 	// golang.org/x/crypto/argon2
-	time    = uint32(1)
-	memory  = uint32(64 * 1024) // 64MB
-	threads = uint8(runtime.NumCPU())
+	time    = uint32(1)               //nolint:gochecknoglobals
+	memory  = uint32(64 * 1024)       //nolint:gochecknoglobals  // 64MB
+	threads = uint8(runtime.NumCPU()) //nolint:gochecknoglobals
 )
 
 // Enc is an AEAD cipher mode providing authenticated encryption with associated data, ie [cipher.AEAD]

--- a/cry/enc.go
+++ b/cry/enc.go
@@ -8,16 +8,17 @@ import (
 	cryptoRand "crypto/rand"
 	"encoding/base64"
 	"errors"
+	"runtime"
 	"slices"
 
 	"github.com/komuw/ong/internal/key"
 
+	"golang.org/x/crypto/argon2"
 	"golang.org/x/crypto/chacha20poly1305"
-	"golang.org/x/crypto/scrypt"
 )
 
 // Latacora recommends ChaCha20-Poly1305 for encryption.
-// https://latacora.micro.blog/2018/04/03/cryptographic-right-answers.html
+// https://www.latacora.com/blog/2024/07/29/crypto-right-answers-pq/
 //
 // The Go authors also recommend to use `crypto/cipher.NewGCM` or `XChaCha20-Poly1305`
 // https://github.com/golang/crypto/blob/05595931fe9d3f8894ab063e1981d28e9873e2cb/tea/cipher.go#L13-L14
@@ -35,14 +36,15 @@ import (
 const (
 	keyLen  = chacha20poly1305.KeySize
 	saltLen = 8
+)
+
+var (
 	//
-	// The values recommended as of year 2017 are:
-	// n=32768, r=8 and p=1
-	// https://pkg.go.dev/golang.org/x/crypto/scrypt#Key
-	//
-	n = 32768 // CPU/memory cost parameter.
-	r = 8     // r and p must satisfy r * p < 2³⁰, else [scrypt.Key] returns an error.
-	p = 1
+	// The values recommended are:
+	// golang.org/x/crypto/argon2
+	time    = uint32(1)
+	memory  = uint32(64 * 1024) // 64MB
+	threads = uint8(runtime.NumCPU())
 )
 
 // Enc is an AEAD cipher mode providing authenticated encryption with associated data, ie [cipher.AEAD]
@@ -58,7 +60,7 @@ type Enc struct {
 //
 // It panics on error.
 //
-// It uses [scrypt] to derive the final key that will be used for encryption.
+// It uses argon2id to derive the final key that will be used for encryption.
 func New(secretKey string) Enc {
 	// I think it is okay for New to panic instead of returning an error.
 	// Since this is a crypto library, it is better to fail loudly than fail silently.
@@ -71,16 +73,12 @@ func New(secretKey string) Enc {
 	// derive a key.
 	password := []byte(secretKey)
 	salt := random(saltLen, saltLen) // should be random, 8 bytes is a good length.
-	derivedKey, err := deriveKey(password, salt)
-	if err != nil {
-		panic(err)
-	}
+	derivedKey := deriveKey(password, salt)
 
 	/*
 		Another option would be to use argon2.
-		  import "golang.org/x/crypto/argon2"
-		  salt := rand(16, 16) // 16bytes are recommended
-		  key := argon2.Key( []byte("super-h@rd-Pas1word"), salt, 3, 32 * 1024, 4, keyLen)
+		  import "golang.org/x/crypto/scrypt"
+		  key := scrypt.Key("password", salt, 32768, 8, 1, keyLen)
 	*/
 
 	// xchacha20poly1305 takes a longer nonce, suitable to be generated randomly without risk of collisions.
@@ -136,10 +134,7 @@ func (e Enc) Decrypt(encryptedMsg []byte) (decryptedMsg []byte, err error) {
 	if !slices.Equal(salt, e.salt) {
 		// The encryptedMsg was encrypted using a different salt.
 		// So, we need to get the derived key for that salt and use it for decryption.
-		derivedKey, errK := scrypt.Key(e.key, salt, n, r, p, keyLen)
-		if errK != nil {
-			return nil, errK
-		}
+		derivedKey := argon2.IDKey(e.key, salt, time, memory, threads, keyLen)
 
 		aead, err = chacha20poly1305.NewX(derivedKey)
 		if err != nil {

--- a/cry/example_test.go
+++ b/cry/example_test.go
@@ -41,12 +41,9 @@ func ExampleEnc_EncryptEncode() {
 func ExampleHash() {
 	password := "my NSA-hard password"
 	// it is okay to save hashedPasswd to the database, as an example.
-	hashedPasswd, err := cry.Hash(password)
-	if err != nil {
-		panic(err)
-	}
+	hashedPasswd := cry.Hash(password)
 
-	err = cry.Eql(password, hashedPasswd)
+	err := cry.Eql(password, hashedPasswd)
 	if err != nil {
 		panic(err)
 	}

--- a/cry/hash.go
+++ b/cry/hash.go
@@ -15,16 +15,17 @@ import (
 //   (a) https://github.com/elithrar/simple-scrypt whose license(MIT) can be found here: https://github.com/elithrar/simple-scrypt/blob/v1.3.0/LICENSE
 
 const (
-	// this should be increased every time the parameters passed to [scrypt.Key] are changed.
+	// this should be increased every time the parameters passed to [argon2.IDKey] are changed.
 	version   = 1
 	separator = "$"
 )
 
 func deriveKey(password, salt []byte) []byte {
+	// IDKey is Argon2id
 	return argon2.IDKey(password, salt, time, memory, threads, keyLen)
 }
 
-// Hash returns the scrypt hash of the password.
+// Hash returns the argon2id hash of the password.
 // It is safe to persist the result in your database instead of storing the actual password.
 func Hash(password string) string {
 	salt := random(saltLen, saltLen)

--- a/cry/hash_test.go
+++ b/cry/hash_test.go
@@ -14,8 +14,7 @@ func TestHash(t *testing.T) {
 		t.Parallel()
 
 		password := "hey ok"
-		hash, err := Hash(password)
-		attest.Ok(t, err)
+		hash := Hash(password)
 		attest.NotZero(t, hash)
 	})
 
@@ -23,11 +22,10 @@ func TestHash(t *testing.T) {
 		t.Parallel()
 
 		password := "hey ok"
-		hash, err := Hash(password)
-		attest.Ok(t, err)
+		hash := Hash(password)
 		attest.NotZero(t, hash)
 
-		err = Eql(password, hash)
+		err := Eql(password, hash)
 		attest.Ok(t, err)
 	})
 
@@ -35,12 +33,11 @@ func TestHash(t *testing.T) {
 		t.Parallel()
 
 		password := "hey ok"
-		hash, err := Hash(password)
-		attest.Ok(t, err)
+		hash := Hash(password)
 		attest.NotZero(t, hash)
 
 		hash = strings.ReplaceAll(hash, separator, "-")
-		err = Eql(password, hash)
+		err := Eql(password, hash)
 		attest.Error(t, err)
 	})
 }

--- a/example/handlers.go
+++ b/example/handlers.go
@@ -269,11 +269,7 @@ func (a app) login(secretKey string) http.HandlerFunc {
 		existingPasswdHash := a.db.Get("passwd")
 		if e := cry.Eql(password, existingPasswdHash); e != nil {
 			// passwd did not exist before.
-			hashedPasswd, errH := cry.Hash(password)
-			if errH != nil {
-				http.Error(w, errH.Error(), http.StatusInternalServerError)
-				return
-			}
+			hashedPasswd := cry.Hash(password)
 			a.db.Set("passwd", hashedPasswd)
 		}
 


### PR DESCRIPTION
- Latacora now recommends argon2id instead of scrypt

https://www.latacora.com/blog/2024/07/29/crypto-right-answers-pq/