### PR TITLE
ong/middleware: logFunc should not be passed a http.ResponseWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Most recent version is listed first.  
 
 
+# v0.1.9
+- ong/middleware: logFunc should not be passed a http.ResponseWriter: https://github.com/komuw/ong/pull/474
+
 # v0.1.8
 - ong/middleware: Make loadshed percentile configurable: https://github.com/komuw/ong/pull/473
 

--- a/config/config.go
+++ b/config/config.go
@@ -262,7 +262,7 @@ func New(
 	// middleware
 	secretKey string,
 	strategy ClientIPstrategy,
-	logFunc func(w http.ResponseWriter, r http.Request, statusCode int, fields []any),
+	logFunc func(r http.Request, response http.Header, statusCode int, fields []any),
 	rateLimit float64,
 	loadShedSamplingPeriod time.Duration,
 	loadShedMinSampleSize int,
@@ -647,7 +647,7 @@ type middlewareOpts struct {
 	// - https://go.dev/play/p/wL2gqumZ23b
 	SecretKey secureKey
 	Strategy  ClientIPstrategy
-	LogFunc   func(w http.ResponseWriter, r http.Request, statusCode int, fields []any)
+	LogFunc   func(r http.Request, response http.Header, statusCode int, fields []any)
 
 	// ratelimit
 	RateLimit float64
@@ -725,7 +725,7 @@ func newMiddlewareOpts(
 	logger *slog.Logger,
 	secretKey string,
 	strategy ClientIPstrategy,
-	logFunc func(w http.ResponseWriter, r http.Request, statusCode int, fields []any),
+	logFunc func(r http.Request, response http.Header, statusCode int, fields []any),
 	rateLimit float64,
 	loadShedSamplingPeriod time.Duration,
 	loadShedMinSampleSize int,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -36,7 +36,7 @@ func validOpts(t *testing.T) Opts {
 		// In this case, the actual client IP address is fetched from the given http header.
 		SingleIpStrategy("CF-Connecting-IP"),
 		// function to use for logging in middlewares.
-		func(_ http.ResponseWriter, r http.Request, statusCode int, fields []any) {
+		func(r http.Request, response http.Header, statusCode int, fields []any) {
 			reqL := log.WithID(r.Context(), l)
 			reqL.Info("request-and-response", fields...)
 		},

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -33,7 +33,7 @@ func ExampleNew() {
 		// In this case, the actual client IP address is fetched from the given http header.
 		config.SingleIpStrategy("CF-Connecting-IP"),
 		// function to use for logging in middlewares
-		func(_ http.ResponseWriter, r http.Request, statusCode int, fields []any) {
+		func(r http.Request, response http.Header, statusCode int, fields []any) {
 			if statusCode >= http.StatusInternalServerError {
 				// Only log 500's
 				reqL := log.WithID(r.Context(), l)

--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -15,7 +15,7 @@ import (
 // When/if a panic occurs, it logs the stack trace and returns an InternalServerError response.
 func recoverer(
 	wrappedHandler http.Handler,
-	logFunc func(w http.ResponseWriter, r http.Request, statusCode int, fields []any),
+	logFunc func(r http.Request, response http.Header, statusCode int, fields []any),
 	l *slog.Logger,
 ) http.HandlerFunc {
 	code := http.StatusInternalServerError
@@ -58,7 +58,7 @@ func recoverer(
 				}
 				flds = append(flds, extra...)
 
-				logFunc(w, *r, code, flds)
+				logFunc(*r, w.Header().Clone(), code, flds)
 
 				// respond.
 				http.Error(


### PR DESCRIPTION
- Doing so risks the app developers mutating the response in unwanted ways.
  Logging functionality has no business mutating responses or requests.