### PR TITLE
issues/480: mux; add flexible pattern

### DIFF
--- a/internal/mx/mx_test.go
+++ b/internal/mx/mx_test.go
@@ -464,6 +464,17 @@ func TestMuxFlexiblePattern(t *testing.T) {
 			attest.Equal(t, res.StatusCode, http.StatusOK)
 			attest.Equal(t, string(rb), msg)
 		}
+
+		{
+			res, err := client.Get(ts.URL + "/hey/a/b/cool")
+			attest.Ok(t, err)
+
+			rb, err := io.ReadAll(res.Body)
+			attest.Ok(t, err)
+
+			attest.Equal(t, res.StatusCode, http.StatusOK)
+			attest.Equal(t, string(rb), msg)
+		}
 	})
 
 	t.Run("conflict", func(t *testing.T) {

--- a/internal/mx/mx_test.go
+++ b/internal/mx/mx_test.go
@@ -488,19 +488,16 @@ func TestMuxKomu(t *testing.T) {
 		attest.Ok(t, err)
 		defer ts.Close()
 
-		// {
-		// 	rec := httptest.NewRecorder()
-		// 	req := httptest.NewRequest(http.MethodGet, "/UnknownUri", nil)
-		// 	mux.ServeHTTP(rec, req)
+		{
+			res, err := client.Get(ts.URL + "/UnknownUri")
+			attest.Ok(t, err)
 
-		// 	res := rec.Result()
-		// 	defer res.Body.Close()
+			rb, err := io.ReadAll(res.Body)
+			attest.Ok(t, err)
 
-		// 	_, err := io.ReadAll(res.Body)
-		// 	attest.Ok(t, err)
-
-		// 	attest.Equal(t, res.StatusCode, http.StatusNotFound)
-		// }
+			attest.Equal(t, res.StatusCode, http.StatusOK)
+			attest.Equal(t, string(rb), msg)
+		}
 
 		{
 			res, err := client.Get(ts.URL + "/")

--- a/internal/mx/mx_test.go
+++ b/internal/mx/mx_test.go
@@ -444,33 +444,33 @@ func TestMuxFlexiblePattern(t *testing.T) {
 		defer ts.Close()
 
 		{
-			res, err := client.Get(ts.URL + "/UnknownUri")
-			attest.Ok(t, err)
+			res, errA := client.Get(ts.URL + "/UnknownUri")
+			attest.Ok(t, errA)
 
-			rb, err := io.ReadAll(res.Body)
-			attest.Ok(t, err)
-
-			attest.Equal(t, res.StatusCode, http.StatusOK)
-			attest.Equal(t, string(rb), msg)
-		}
-
-		{
-			res, err := client.Get(ts.URL + "/")
-			attest.Ok(t, err)
-
-			rb, err := io.ReadAll(res.Body)
-			attest.Ok(t, err)
+			rb, errB := io.ReadAll(res.Body)
+			attest.Ok(t, errB)
 
 			attest.Equal(t, res.StatusCode, http.StatusOK)
 			attest.Equal(t, string(rb), msg)
 		}
 
 		{
-			res, err := client.Get(ts.URL + "/hey/a/b/cool")
-			attest.Ok(t, err)
+			res, errC := client.Get(ts.URL + "/")
+			attest.Ok(t, errC)
 
-			rb, err := io.ReadAll(res.Body)
-			attest.Ok(t, err)
+			rb, errD := io.ReadAll(res.Body)
+			attest.Ok(t, errD)
+
+			attest.Equal(t, res.StatusCode, http.StatusOK)
+			attest.Equal(t, string(rb), msg)
+		}
+
+		{
+			res, errE := client.Get(ts.URL + "/hey/a/b/cool")
+			attest.Ok(t, errE)
+
+			rb, errF := io.ReadAll(res.Body)
+			attest.Ok(t, errF)
 
 			attest.Equal(t, res.StatusCode, http.StatusOK)
 			attest.Equal(t, string(rb), msg)

--- a/internal/mx/route.go
+++ b/internal/mx/route.go
@@ -70,13 +70,13 @@ func NewRoute(
 }
 
 func (r Route) match(ctx context.Context, segs []string) (context.Context, bool) {
-	if len(segs) > len(r.segments) {
-		return nil, false
-	}
-
 	if len(r.segments) == 1 && r.segments[0] == "*" {
 		// The router is allowed to handle all request paths
 		return ctx, true
+	}
+
+	if len(segs) > len(r.segments) {
+		return nil, false
 	}
 
 	for i, seg := range r.segments {

--- a/internal/mx/route.go
+++ b/internal/mx/route.go
@@ -73,6 +73,12 @@ func (r Route) match(ctx context.Context, segs []string) (context.Context, bool)
 	if len(segs) > len(r.segments) {
 		return nil, false
 	}
+
+	if len(r.segments) == 1 && r.segments[0] == "*" {
+		// The router is allowed to handle all request paths
+		return ctx, true
+	}
+
 	for i, seg := range r.segments {
 		if i > len(segs)-1 {
 			return nil, false
@@ -91,6 +97,7 @@ func (r Route) match(ctx context.Context, segs []string) (context.Context, bool)
 			ctx = context.WithValue(ctx, muxContextKey(seg), segs[i])
 		}
 	}
+
 	return ctx, true
 }
 

--- a/internal/mx/route.go
+++ b/internal/mx/route.go
@@ -229,6 +229,10 @@ already exists and would conflict`,
 			getfunc(rt.originalHandler),
 		)
 
+		if len(existingSegments) == 1 && existingSegments[0] == "*" && len(incomingSegments) > 0 {
+			return errMsg
+		}
+
 		if pattern == rt.pattern {
 			return errMsg
 		}


### PR DESCRIPTION
- Fixes: https://github.com/komuw/ong/issues/480
- This allows someone to add a route that will handle all request paths
```go
rt, err := NewRoute("/*", "GET", someHandler(msg))
mux, err := New(opts, nil, rt)
```
That will be able to handle requests for `/`, `/hello`, `/he/okay/poor`

I've released `v0.1.12-beta` for testing.